### PR TITLE
[Feat] 번개 신청 뷰 UI 구현 및 서버 연동

### DIFF
--- a/PlayTogether/PlayTogether.xcodeproj/project.pbxproj
+++ b/PlayTogether/PlayTogether.xcodeproj/project.pbxproj
@@ -98,6 +98,10 @@
 		DDB380D128C08BC2001826B0 /* OpenedDetailThunViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB380D028C08BC2001826B0 /* OpenedDetailThunViewController.swift */; };
 		DDB380D328C08DEB001826B0 /* DeleteThunService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB380D228C08DEB001826B0 /* DeleteThunService.swift */; };
 		DDB380D528C08E73001826B0 /* DeleteThunViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB380D428C08E73001826B0 /* DeleteThunViewModel.swift */; };
+		DDB380DF28C19E5E001826B0 /* EnterDetailThunViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB380DE28C19E5E001826B0 /* EnterDetailThunViewController.swift */; };
+		DDB380E128C1A971001826B0 /* ExistThunResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB380E028C1A971001826B0 /* ExistThunResponse.swift */; };
+		DDB380E328C1A992001826B0 /* ExistThunService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB380E228C1A992001826B0 /* ExistThunService.swift */; };
+		DDB380E528C1AA8D001826B0 /* ExistThunViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB380E428C1AA8D001826B0 /* ExistThunViewModel.swift */; };
 		DDBE87B12892536A0042490C /* ThunResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBE87B02892536A0042490C /* ThunResponse.swift */; };
 		DDBE87B5289257CA0042490C /* ThunService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBE87B4289257CA0042490C /* ThunService.swift */; };
 		DDF2C4012887A60F00C10F67 /* UnderlineSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF2C4002887A60F00C10F67 /* UnderlineSegmentedControl.swift */; };
@@ -195,6 +199,10 @@
 		DDB380D028C08BC2001826B0 /* OpenedDetailThunViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenedDetailThunViewController.swift; sourceTree = "<group>"; };
 		DDB380D228C08DEB001826B0 /* DeleteThunService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteThunService.swift; sourceTree = "<group>"; };
 		DDB380D428C08E73001826B0 /* DeleteThunViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteThunViewModel.swift; sourceTree = "<group>"; };
+		DDB380DE28C19E5E001826B0 /* EnterDetailThunViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnterDetailThunViewController.swift; sourceTree = "<group>"; };
+		DDB380E028C1A971001826B0 /* ExistThunResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistThunResponse.swift; sourceTree = "<group>"; };
+		DDB380E228C1A992001826B0 /* ExistThunService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistThunService.swift; sourceTree = "<group>"; };
+		DDB380E428C1AA8D001826B0 /* ExistThunViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistThunViewModel.swift; sourceTree = "<group>"; };
 		DDBE87B02892536A0042490C /* ThunResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThunResponse.swift; sourceTree = "<group>"; };
 		DDBE87B4289257CA0042490C /* ThunService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThunService.swift; sourceTree = "<group>"; };
 		DDF2C4002887A60F00C10F67 /* UnderlineSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnderlineSegmentedControl.swift; sourceTree = "<group>"; };
@@ -298,6 +306,8 @@
 				DD36D39428A4C99B00C9851A /* GoThunListViewController.swift */,
 				DD36D39628A4C9A800C9851A /* DoThunListViewController.swift */,
 				40DCE5C328BA866E00EE31B0 /* HomeEmptyView.swift */,
+				DDB380DE28C19E5E001826B0 /* EnterDetailThunViewController.swift */,
+				DDB380CE28BE4511001826B0 /* CompleteThunViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -318,6 +328,8 @@
 				409451AE28905A9000F21717 /* HomeService.swift */,
 				409451B228905D7D00F21717 /* HomeResponse.swift */,
 				40AA766628A2B91F0093A3EB /* CreateThunService.swift */,
+				DDB380E028C1A971001826B0 /* ExistThunResponse.swift */,
+				DDB380E228C1A992001826B0 /* ExistThunService.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -327,6 +339,7 @@
 			children = (
 				409451B728905FDE00F21717 /* HomeViewModel.swift */,
 				4040AC442893096F00C76978 /* CreateThunViewModel.swift */,
+				DDB380E428C1AA8D001826B0 /* ExistThunViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -556,7 +569,6 @@
 				DDB380D028C08BC2001826B0 /* OpenedDetailThunViewController.swift */,
 				DDB380C028BB9A71001826B0 /* LikedDetailThunViewController.swift */,
 				DDB380CC28BD2EAE001826B0 /* SelectImageViewController.swift */,
-				DDB380CE28BE4511001826B0 /* CompleteThunViewController.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -655,12 +667,14 @@
 				4096A2CF287F67E600F1E27C /* UIColor+Extension.swift in Sources */,
 				B6A612FF28A9F36600688DA2 /* CheckNicknameResponse.swift in Sources */,
 				DD36D39528A4C99B00C9851A /* GoThunListViewController.swift in Sources */,
+				DDB380E128C1A971001826B0 /* ExistThunResponse.swift in Sources */,
 				DDB380C328BBA219001826B0 /* LikeThunService.swift in Sources */,
 				404169932886A56C00812B37 /* ThunViewController.swift in Sources */,
 				DD73C2C628B3B44E001DEC1A /* CancelThunViewModel.swift in Sources */,
 				408EE3E928BAB2510012C642 /* MyPageViewModel.swift in Sources */,
 				DDB380D528C08E73001826B0 /* DeleteThunViewModel.swift in Sources */,
 				40727C1628A1B635007E5835 /* UIResponder+Extension.swift in Sources */,
+				DDB380DF28C19E5E001826B0 /* EnterDetailThunViewController.swift in Sources */,
 				DD73C2C228B209DC001DEC1A /* CancelThunResponse.swift in Sources */,
 				DDF2C4032887A83E00C10F67 /* SubmittedThunViewController.swift in Sources */,
 				DD73C2C828B57174001DEC1A /* ThunViewModel.swift in Sources */,
@@ -694,6 +708,7 @@
 				4040AC452893096F00C76978 /* CreateThunViewModel.swift in Sources */,
 				DDB380D128C08BC2001826B0 /* OpenedDetailThunViewController.swift in Sources */,
 				DDF2C4052887A96800C10F67 /* OpenedThunViewController.swift in Sources */,
+				DDB380E328C1A992001826B0 /* ExistThunService.swift in Sources */,
 				DD36D39A28A6676100C9851A /* SubmittedDetailThunViewController.swift in Sources */,
 				409451B828905FDE00F21717 /* HomeViewModel.swift in Sources */,
 				DDB380C928BBA8B6001826B0 /* ExistLikeThunService.swift in Sources */,
@@ -733,6 +748,7 @@
 				408EE3E228BAAF290012C642 /* MyPageSubwayLabel.swift in Sources */,
 				B6ECF18B28B5BAB9003C80AB /* ParticipationCompletedViewController.swift in Sources */,
 				DD36D3A028A67D0700C9851A /* DetailThunImageCollectionViewCell.swift in Sources */,
+				DDB380E528C1AA8D001826B0 /* ExistThunViewModel.swift in Sources */,
 				4096A2BD287F627E00F1E27C /* BaseViewController.swift in Sources */,
 				408EE3E028BAA8C00012C642 /* MyPageSubwayLabelView.swift in Sources */,
 			);

--- a/PlayTogether/PlayTogether/Sources/Common/APIConstants.swift
+++ b/PlayTogether/PlayTogether/Sources/Common/APIConstants.swift
@@ -29,6 +29,7 @@ struct APIConstants {
     static let postLikeThun = "/scrap"
     static let getExistLikeThun = "/scrap/exist"
     static let postDeleteThun = "light/remove"
+    static let getExistThun = "light/exist"
     
     // subway
     static let getStationList = "/getKwrdFndSubwaySttnList"

--- a/PlayTogether/PlayTogether/Sources/Home/Network/ExistThunResponse.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/Network/ExistThunResponse.swift
@@ -1,0 +1,24 @@
+//
+//  ExistThunResponse.swift
+//  PlayTogether
+//
+//  Created by 김수정 on 2022/09/02.
+//
+
+import Foundation
+
+struct ExistThunResponse: Decodable {
+    let status: Int
+    let success: Bool
+    let message: String
+    let data: ExistThun
+}
+
+struct ExistThun: Decodable {
+    let isEntered, isOrganizer: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case isEntered = "is_entered"
+        case isOrganizer = "is_organizer"
+    }
+}

--- a/PlayTogether/PlayTogether/Sources/Home/Network/ExistThunService.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/Network/ExistThunService.swift
@@ -1,0 +1,45 @@
+
+
+import Foundation
+import Moya
+
+enum ExistThunService {
+    case existThunRequest(lightId: Int)
+}
+
+extension ExistThunService: TargetType {
+    var baseURL: URL {
+        return URL(string: APIConstants.baseUrl)!
+    }
+    
+    var path: String {
+        switch self {
+        case .existThunRequest(let lightId):
+            return "\(APIConstants.getExistThun)" + "/\(lightId)"
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .existThunRequest:
+            return .get
+        }
+    }
+    
+    var task: Task {
+        switch self {
+        case .existThunRequest:
+            return .requestPlain
+        }
+    }
+    
+    var headers: [String: String]? {
+        let token = APIConstants.token
+        return [
+            "Content-Type": "application/json",
+            "Authorization": token
+        ]
+    }
+}
+
+

--- a/PlayTogether/PlayTogether/Sources/Home/Network/ExistThunService.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/Network/ExistThunService.swift
@@ -15,7 +15,7 @@ extension ExistThunService: TargetType {
     var path: String {
         switch self {
         case .existThunRequest(let lightId):
-            return "\(APIConstants.getExistThun)" + "/\(lightId)"
+            return APIConstants.getExistThun + "/\(lightId)"
         }
     }
     

--- a/PlayTogether/PlayTogether/Sources/Home/View/CompleteThunViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/View/CompleteThunViewController.swift
@@ -1,8 +1,6 @@
 import UIKit
 import RxSwift
 
-// MARK: tableView rx로 바꿀 때, memberTableView의 높이 값도 변경해줘야함
-// MARK: SubmittedDetailThunViewController의 memberTableView setupBinding()부분을 참고해서 바꾸면 됌
 class CompleteThunViewController: BaseViewController {
     private lazy var disposeBag = DisposeBag()
 
@@ -23,7 +21,7 @@ class CompleteThunViewController: BaseViewController {
     }
 
     private let completeLabel = UILabel().then {
-        $0.text = "번개 오픈을\n완료했어요!"
+        $0.text = "번개 신청을\n완료했어요!"
         $0.numberOfLines = 0
         $0.font = .pretendardRegular(size: 22)
         $0.textColor = .white

--- a/PlayTogether/PlayTogether/Sources/Home/View/EnterDetailThunViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/View/EnterDetailThunViewController.swift
@@ -242,9 +242,9 @@ class EnterDetailThunViewController: BaseViewController {
         }
         
         imageCollectionView.snp.makeConstraints {
-            $0.top.equalTo(textInfoLabel.snp.bottom)
+            $0.top.equalTo(textInfoLabel.snp.bottom).offset(20)
             $0.leading.trailing.equalTo(textInfoLabel)
-            $0.height.equalTo(1)
+            $0.height.equalTo((UIScreen.main.bounds.height / 812) * 91)
             $0.bottom.equalToSuperview().offset(-20)
         }
         
@@ -298,14 +298,14 @@ class EnterDetailThunViewController: BaseViewController {
                     ) as? DetailThunImageCollectionViewCell
                     else { return UICollectionViewCell() }
                     
-                    if item.isEmpty == false {
+                    if item.isEmpty {
                         self.imageCollectionView.snp.updateConstraints {
-                            $0.top.equalTo(self.textInfoLabel.snp.bottom).offset(20)
-                            $0.height.equalTo((UIScreen.main.bounds.height / 812) * 91)
+                            $0.top.equalTo(self.textInfoLabel.snp.bottom)
+                            $0.height.equalTo(1)
                         }
-                        cell.imageView.loadImage(url: image)
-                        self.imageCount = [image].count
                     }
+                    cell.imageView.loadImage(url: image)
+                    self.imageCount = [image].count
                     return cell
                 }
                 .disposed(by: self.disposeBag)

--- a/PlayTogether/PlayTogether/Sources/Home/View/EnterDetailThunViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/View/EnterDetailThunViewController.swift
@@ -1,0 +1,398 @@
+//
+//  DetailThunViewController.swift
+//  PlayTogether
+//
+//  Created by 김수정 on 2022/08/12.
+//
+
+import UIKit
+import RxSwift
+import SnapKit
+import Then
+
+class EnterDetailThunViewController: BaseViewController {
+    private lazy var disposeBag = DisposeBag()
+    private let viewModel = DetailThunViewModel()
+    private let likeThunViewModel = LikeThunViewModel()
+    private let superViewModel = ThunViewModel()
+    private let cancelViewModel = CancelThunViewModel()
+    private let existThunViewModel = ExistThunViewModel()
+    var lightId: Int?
+    var imageCount: Int?
+    
+    init(lightID: Int) {
+        self.lightId = lightID
+        super.init()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private let scrollView = UIScrollView().then {
+        $0.contentInsetAdjustmentBehavior = .never
+        $0.showsVerticalScrollIndicator = false
+    }
+    
+    private let enterButton = UIButton().then {
+        $0.isButtonEnableUI(check: true)
+    }
+    
+    private let contentView = UIView()
+    
+    private let backButton = UIButton().then {
+        $0.setImage(.ptImage(.backIcon), for: .normal)
+    }
+    
+    private let likeButton = UIButton().then {
+        $0.setImage(.ptImage(.navLikeDefaultIcon), for: .normal)
+        $0.setImage(.ptImage(.navLikeFilledGreenIcon), for: .selected)
+    }
+    
+    private let circleImageView = UIImageView().then {
+        $0.image = .ptImage(.profileIcon)
+    }
+    
+    private let nicknameLabel = UILabel().then {
+        $0.font = .pretendardBold(size: 14)
+        $0.textColor = .ptBlack01
+    }
+    
+    private let messageButton = UIButton().then {
+        $0.setTitle("쪽지", for: .normal)
+        $0.backgroundColor = .ptBlack02
+        $0.titleLabel?.font = .pretendardMedium(size: 12)
+        $0.layer.cornerRadius = 14
+    }
+    
+    private let underLineView = UIView().then {
+        $0.backgroundColor = .ptGray03
+    }
+    
+    private let blackView = UIView().then {
+        $0.backgroundColor = .ptBlack01
+        $0.layer.cornerRadius = 10
+    }
+    
+    private let titleLabel = UILabel().then {
+        $0.textColor = .ptGreen
+        $0.font = .pretendardBold(size: 20)
+    }
+    
+    private let dateLabel = UILabel().then {
+        $0.font = .pretendardMedium(size: 14)
+        $0.textColor = .white
+    }
+    
+    private let timeLabel = UILabel().then {
+        $0.font = .pretendardMedium(size: 14)
+        $0.textColor = .white
+    }
+    
+    private let placeLabel = UILabel().then {
+        $0.font = .pretendardMedium(size: 14)
+        $0.textColor = .white
+    }
+    
+    private let categoryLabel = UILabel().then {
+        $0.font = .pretendardMedium(size: 14)
+        $0.textColor = .white
+    }
+    
+    private lazy var labelStackView = UIStackView(
+        arrangedSubviews:[dateLabel,timeLabel,placeLabel,categoryLabel]
+    ).then {
+        $0.axis = .vertical
+        $0.spacing = 22
+    }
+    
+    private let dashedLineView = UIView().then {
+        let shapeLayer = CAShapeLayer()
+        shapeLayer.strokeColor = UIColor.white.cgColor
+        shapeLayer.lineWidth = 1
+        shapeLayer.lineDashPattern = [2, 2]
+        let path = CGMutablePath()
+        path.addLines(between: [CGPoint(x: 0, y: 0), CGPoint(x: UIScreen.main.bounds.width, y: 0)])
+        shapeLayer.path = path
+        $0.layer.addSublayer(shapeLayer)
+    }
+    
+    private let textInfoLabel = UILabel().then {
+        $0.numberOfLines = 0
+        $0.textColor = .white
+        $0.font = .pretendardRegular(size: 14)
+    }
+    
+    private lazy var imageCollectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: UICollectionViewFlowLayout()
+    ).then {
+        let collectionViewLayout = UICollectionViewFlowLayout()
+        let width = (UIScreen.main.bounds.width / 375) * 273
+        let height = (UIScreen.main.bounds.height / 812) * 91
+        collectionViewLayout.itemSize = CGSize(width: width/3, height: height)
+        collectionViewLayout.minimumLineSpacing = 15
+        $0.collectionViewLayout = collectionViewLayout
+        
+        $0.backgroundColor = .ptBlack01
+        $0.register(
+            DetailThunImageCollectionViewCell.self,
+            forCellWithReuseIdentifier: "DetailThunImageCollectionViewCell"
+        )
+        $0.showsHorizontalScrollIndicator = false
+        $0.isScrollEnabled = false
+    }
+    
+    private let alertButton = UIButton().then {
+        $0.setTitle("게시글 신고", for: .normal)
+        $0.setTitleColor(.ptGray01, for: .normal)
+        $0.titleLabel?.font = .pretendardRegular(size: 12)
+        $0.setUnderline()
+    }
+    
+    override func setupViews() {
+        view.backgroundColor = .white
+        tabBarController?.tabBar.isHidden = true
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: likeButton)
+        
+        view.addSubview(scrollView)
+        view.addSubview(enterButton)
+        
+        scrollView.addSubview(contentView)
+        
+        contentView.addSubview(circleImageView)
+        contentView.addSubview(nicknameLabel)
+        contentView.addSubview(messageButton)
+        contentView.addSubview(underLineView)
+        contentView.addSubview(blackView)
+        contentView.addSubview(alertButton)
+        
+        blackView.addSubview(titleLabel)
+        blackView.addSubview(dateLabel)
+        blackView.addSubview(timeLabel)
+        blackView.addSubview(placeLabel)
+        blackView.addSubview(categoryLabel)
+        blackView.addSubview(labelStackView)
+        blackView.addSubview(dashedLineView)
+        blackView.addSubview(textInfoLabel)
+        blackView.addSubview(imageCollectionView)
+    }
+    
+    override func setupLayouts() {
+        scrollView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        enterButton.snp.makeConstraints {
+            $0.top.equalTo(scrollView.snp.bottom).offset(12)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().inset(40)
+            $0.height.equalTo(56 * UIScreen.main.bounds.height/812)
+        }
+        
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.width.equalTo(scrollView.snp.width)
+        }
+        
+        circleImageView.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(20)
+            $0.leading.equalToSuperview().offset(20)
+            $0.size.equalTo(CGSize(width: 40, height: 40))
+        }
+        
+        nicknameLabel.snp.makeConstraints {
+            $0.leading.equalTo(circleImageView.snp.trailing).offset(5)
+            $0.centerY.equalTo(circleImageView.snp.centerY)
+        }
+        
+        messageButton.snp.makeConstraints {
+            $0.centerY.equalTo(nicknameLabel.snp.centerY)
+            $0.trailing.equalToSuperview().offset(-27)
+            $0.size.equalTo(CGSize(width: 52, height: 26))
+        }
+        
+        underLineView.snp.makeConstraints {
+            $0.top.equalTo(circleImageView.snp.bottom).offset(20)
+            $0.leading.equalTo(circleImageView.snp.leading)
+            $0.trailing.equalTo(messageButton.snp.trailing).offset(7)
+            $0.height.equalTo(1)
+        }
+        
+        blackView.snp.makeConstraints {
+            $0.top.equalTo(underLineView.snp.bottom).offset(30)
+            $0.leading.trailing.equalTo(underLineView)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(20)
+            $0.leading.equalToSuperview().offset(16)
+        }
+        
+        labelStackView.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(30)
+            $0.leading.equalTo(titleLabel.snp.leading)
+        }
+        
+        dashedLineView.snp.makeConstraints {
+            $0.top.equalTo(labelStackView.snp.bottom).offset(30)
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        imageCollectionView.snp.makeConstraints {
+            $0.top.equalTo(textInfoLabel.snp.bottom)
+            $0.leading.trailing.equalTo(textInfoLabel)
+            $0.height.equalTo(1)
+            $0.bottom.equalToSuperview().offset(-20)
+        }
+        
+        textInfoLabel.snp.makeConstraints {
+            if imageCollectionView.frame.height == 1 {
+                $0.top.equalTo(dashedLineView.snp.bottom).offset(20)
+                $0.leading.equalTo(labelStackView.snp.leading)
+                $0.trailing.equalToSuperview().offset(-16)
+                $0.bottom.equalToSuperview().inset(20)
+            } else {
+                $0.top.equalTo(dashedLineView.snp.bottom).offset(20)
+                $0.leading.equalTo(labelStackView.snp.leading)
+                $0.trailing.equalToSuperview().offset(-16)
+            }
+        }
+        
+        alertButton.snp.makeConstraints {
+            $0.top.equalTo(blackView.snp.bottom).offset(15)
+            $0.trailing.equalToSuperview().offset(-33)
+            $0.bottom.equalToSuperview()
+        }
+    }
+    
+    override func setupBinding() {
+        viewModel.getDetailThunList(lightId: lightId ?? -1) { response in
+            let nameResponse = response[0].organizer
+            self.setupData(
+                response[0].title,
+                response[0].date ?? "날짜 미정",
+                response[0].time ?? "시간 미정",
+                response[0].datumDescription ?? "",
+                response[0].place ?? "장소 미정",
+                response[0].category,
+                nameResponse[0].name,
+                response[0].peopleCnt ?? 0,
+                response[0].lightMemberCnt
+            )
+        }
+        
+        likeThunViewModel.getExistLikeThun(lightId: lightId ?? -1) {
+            self.likeButton.isSelected = $0
+        }
+        
+        viewModel.getImageList(lightId: lightId ?? -1) { image in
+            Observable.of([image])
+                .bind(to: self.imageCollectionView.rx.items) {
+                    _, row, item -> UICollectionViewCell in
+                    guard let cell = self.imageCollectionView.dequeueReusableCell(
+                        withReuseIdentifier: "DetailThunImageCollectionViewCell",
+                        for: IndexPath(row: row, section: 0)
+                    ) as? DetailThunImageCollectionViewCell
+                    else { return UICollectionViewCell() }
+                    
+                    if item.isEmpty == false {
+                        self.imageCollectionView.snp.updateConstraints {
+                            $0.top.equalTo(self.textInfoLabel.snp.bottom).offset(20)
+                            $0.height.equalTo((UIScreen.main.bounds.height / 812) * 91)
+                        }
+                        cell.imageView.loadImage(url: image)
+                        self.imageCount = [image].count
+                    }
+                    return cell
+                }
+                .disposed(by: self.disposeBag)
+        }
+    
+        backButton.rx.tap
+            .asDriver()
+            .drive(onNext: { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+                self?.tabBarController?.tabBar.isHidden = false
+            })
+            .disposed(by: disposeBag)
+        
+        likeButton.rx.tap
+            .asDriver()
+            .drive(onNext: { [weak self] in
+                self?.likeThunViewModel.postLikeThun(lightId: self?.lightId ?? -1) {
+                    self?.likeButton.isSelected = !$0
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        imageCollectionView.rx.itemSelected
+            .asDriver()
+            .drive(onNext: { [weak self] indexPath in
+                let nextVC = SelectImageViewController(lightID: self?.lightId ?? -1, indexPath: indexPath.row, imageCount: self?.imageCount ?? 0)
+                nextVC.modalPresentationStyle = .fullScreen
+                self?.present(nextVC, animated: true, completion: nil)
+            })
+            .disposed(by: disposeBag)
+        
+        enterButton.rx.tap
+            .asDriver()
+            .drive(onNext: { [weak self] in
+                let popupViewController = PopUpViewController(title: "번개에 참여할까요?", viewType: .twoButton)
+                self?.present(popupViewController, animated: false, completion: nil)
+                popupViewController.delegate = self
+            })
+            .disposed(by: disposeBag)
+        
+        existThunViewModel.getExistThun(lightId: lightId ?? -1) {_ in
+            if self.existThunViewModel.isExistThun == true {
+                self.enterButton.isHidden = true
+                self.enterButton.snp.updateConstraints {
+                    $0.height.equalTo(0)
+                }
+            } else {
+                self.enterButton.isHidden = false
+            }
+        }
+    }
+}
+
+extension EnterDetailThunViewController {
+    func setupData(
+        _ title: String,
+        _ date: String,
+        _ time: String,
+        _ description: String,
+        _ place: String,
+        _ category: String,
+        _ name: String,
+        _ peopleCnt: Int,
+        _ lightMemberCnt: Int
+    ){
+        let dateStr = date.replacingOccurrences(of: "-", with: ".")
+        titleLabel.text = title
+        dateLabel.text = "날짜  \(dateStr)"
+        dateLabel.changeFontColor(targetString: "날짜", color: .ptGreen)
+        timeLabel.text = "시간  \(time)"
+        timeLabel.changeFontColor(targetString: "시간", color: .ptGreen)
+        placeLabel.text = "장소  \(place)"
+        placeLabel.changeFontColor(targetString: "장소", color: .ptGreen)
+        categoryLabel.text = "카테고리  \(category)"
+        categoryLabel.changeFontColor(targetString: "카테고리", color: .ptGreen)
+        textInfoLabel.text = description
+        nicknameLabel.text = name
+        enterButton.setupBottomButtonUI(title: "신청하기 (\(lightMemberCnt)/\(peopleCnt))", size: 16)
+    }
+}
+
+extension EnterDetailThunViewController: PopUpConfirmDelegate {
+    func oneButtonDidTap() {}
+    func firstButtonDidTap() {}
+    func secondButtonDidTap() {
+        cancelViewModel.postCancelThun(lightId: lightId ?? -1) {_ in
+            self.navigationController?.pushViewController(CompleteThunViewController(), animated: true)
+        }
+    }
+}

--- a/PlayTogether/PlayTogether/Sources/Home/View/HomeViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/View/HomeViewController.swift
@@ -323,5 +323,23 @@ final class HomeViewController: BaseViewController {
                 self?.tabBarController?.tabBar.isHidden = true
             }
             .disposed(by: disposeBag)
+        
+        hotCollectionView.rx.modelSelected(HomeResponseList.self)
+            .asDriver()
+            .drive(onNext: { [weak self] in
+                self?.navigationController?.pushViewController(
+                    EnterDetailThunViewController(
+                        lightID: $0.lightID), animated: true)
+            })
+            .disposed(by: disposeBag)
+        
+        newCollectionView.rx.modelSelected(HomeResponseList.self)
+            .asDriver()
+            .drive(onNext: { [weak self] in
+                self?.navigationController?.pushViewController(
+                    EnterDetailThunViewController(
+                        lightID: $0.lightID), animated: true)
+            })
+            .disposed(by: disposeBag)
     }
 }

--- a/PlayTogether/PlayTogether/Sources/Home/ViewModel/ExistThunViewModel.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/ViewModel/ExistThunViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Moya
+import RxSwift
+
+final class ExistThunViewModel {
+    private lazy var disposeBag = DisposeBag()
+    var isExistThun = false
+    
+    func getExistThun(lightId: Int, completion: @escaping (Bool) -> Void) {
+        let provider = MoyaProvider<ExistThunService>()
+        provider.rx.request(.existThunRequest(lightId: lightId))
+            .subscribe { [weak self] result in
+                switch result {
+                case let .success(response):
+                    let responseData = try? response.map(ExistThunResponse.self)
+                    guard let data = responseData?.message else { return }
+                    
+                    let isExist = data == "해당 번개에 참여중이 아닙니다." ? false : true
+                    self?.isExistThun = isExist
+                    print("여기 나오나 확인", isExist)
+                    completion(isExist)
+                case let .failure(error):
+                    print(error.localizedDescription)
+                }
+            }
+            .disposed(by: disposeBag)
+    }
+}

--- a/PlayTogether/PlayTogether/Sources/Home/ViewModel/ExistThunViewModel.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/ViewModel/ExistThunViewModel.swift
@@ -14,10 +14,8 @@ final class ExistThunViewModel {
                 case let .success(response):
                     let responseData = try? response.map(ExistThunResponse.self)
                     guard let data = responseData?.message else { return }
-                    
                     let isExist = data == "해당 번개에 참여중이 아닙니다." ? false : true
                     self?.isExistThun = isExist
-                    print("여기 나오나 확인", isExist)
                     completion(isExist)
                 case let .failure(error):
                     print(error.localizedDescription)


### PR DESCRIPTION
### 📌 이슈 번호
- #45

### 📌 작업 내역
- 번개 신청 뷰 UI 구현
- 번개 상세 서버 연동
- 번개 신청 api 연동
- 번개 신청 여부 api 연동 및 신청 여부에 따라 신청하기 버튼 있고 없고 구분
- 홈 탭에서 핫, 뉴 클릭 시 나오는 뷰로 연결
- 신청 완료 뷰와 연결
- 찜하기 api & 찜 여부확인 api 연동

### 📌 작업 결과 이미지 또는 영상
https://user-images.githubusercontent.com/53035245/188059382-4cc6d020-924e-4849-aed7-1b55e69724f6.mp4
