### PR TITLE
[Feat] 번개 생성 완료 뷰 서버 연동 

### DIFF
--- a/PlayTogether/PlayTogether.xcodeproj/project.pbxproj
+++ b/PlayTogether/PlayTogether.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		DDB380E128C1A971001826B0 /* ExistThunResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB380E028C1A971001826B0 /* ExistThunResponse.swift */; };
 		DDB380E328C1A992001826B0 /* ExistThunService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB380E228C1A992001826B0 /* ExistThunService.swift */; };
 		DDB380E528C1AA8D001826B0 /* ExistThunViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB380E428C1AA8D001826B0 /* ExistThunViewModel.swift */; };
+		DDB380ED28C27C86001826B0 /* CreateThunResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDB380EC28C27C86001826B0 /* CreateThunResponse.swift */; };
 		DDBE87B12892536A0042490C /* ThunResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBE87B02892536A0042490C /* ThunResponse.swift */; };
 		DDBE87B5289257CA0042490C /* ThunService.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDBE87B4289257CA0042490C /* ThunService.swift */; };
 		DDF2C4012887A60F00C10F67 /* UnderlineSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF2C4002887A60F00C10F67 /* UnderlineSegmentedControl.swift */; };
@@ -203,6 +204,7 @@
 		DDB380E028C1A971001826B0 /* ExistThunResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistThunResponse.swift; sourceTree = "<group>"; };
 		DDB380E228C1A992001826B0 /* ExistThunService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistThunService.swift; sourceTree = "<group>"; };
 		DDB380E428C1AA8D001826B0 /* ExistThunViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistThunViewModel.swift; sourceTree = "<group>"; };
+		DDB380EC28C27C86001826B0 /* CreateThunResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateThunResponse.swift; sourceTree = "<group>"; };
 		DDBE87B02892536A0042490C /* ThunResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThunResponse.swift; sourceTree = "<group>"; };
 		DDBE87B4289257CA0042490C /* ThunService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThunService.swift; sourceTree = "<group>"; };
 		DDF2C4002887A60F00C10F67 /* UnderlineSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnderlineSegmentedControl.swift; sourceTree = "<group>"; };
@@ -328,6 +330,7 @@
 				409451AE28905A9000F21717 /* HomeService.swift */,
 				409451B228905D7D00F21717 /* HomeResponse.swift */,
 				40AA766628A2B91F0093A3EB /* CreateThunService.swift */,
+				DDB380EC28C27C86001826B0 /* CreateThunResponse.swift */,
 				DDB380E028C1A971001826B0 /* ExistThunResponse.swift */,
 				DDB380E228C1A992001826B0 /* ExistThunService.swift */,
 			);
@@ -673,6 +676,7 @@
 				DD73C2C628B3B44E001DEC1A /* CancelThunViewModel.swift in Sources */,
 				408EE3E928BAB2510012C642 /* MyPageViewModel.swift in Sources */,
 				DDB380D528C08E73001826B0 /* DeleteThunViewModel.swift in Sources */,
+				DDB380ED28C27C86001826B0 /* CreateThunResponse.swift in Sources */,
 				40727C1628A1B635007E5835 /* UIResponder+Extension.swift in Sources */,
 				DDB380DF28C19E5E001826B0 /* EnterDetailThunViewController.swift in Sources */,
 				DD73C2C228B209DC001DEC1A /* CancelThunResponse.swift in Sources */,

--- a/PlayTogether/PlayTogether/Sources/Home/Network/CreateThunResponse.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/Network/CreateThunResponse.swift
@@ -1,0 +1,36 @@
+//
+//  CreateThunResponse.swift
+//  PlayTogether
+//
+//  Created by 김수정 on 2022/09/03.
+//
+
+import Foundation
+
+struct CreateThunResponse: Decodable {
+    let status: Int
+    let success: Bool
+    let message: String
+    let data: [CreateThun]
+}
+
+struct CreateThun: Decodable {
+    let id: Int
+    let category, title: String
+    let date, place, time: String?
+    let peopleCnt: Int?
+    let description, image: String
+    let isDeleted: Bool
+    let createdAt, updatedAt: String
+    let organizerID, crewID: Int
+
+    enum CodingKeys: String, CodingKey {
+        case id, category, title, date, place, peopleCnt
+        case description = "description"
+        case image, isDeleted, createdAt, updatedAt
+        case organizerID = "organizerId"
+        case crewID = "crewId"
+        case time
+    }
+}
+

--- a/PlayTogether/PlayTogether/Sources/Home/Network/HomeResponse.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/Network/HomeResponse.swift
@@ -31,3 +31,4 @@ struct HomeResponseList: Decodable {
         case place
     }
 }
+

--- a/PlayTogether/PlayTogether/Sources/Home/View/CompleteThunViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/View/CompleteThunViewController.swift
@@ -6,8 +6,9 @@ final class CompleteThunViewController: BaseViewController {
     private let viewModel = DetailThunViewModel()
     var lightId: Int?
     
-    init(lightID: Int) {
+    init(lightID: Int, completeText: String) {
         self.lightId = lightID
+        self.completeLabel.text = completeText
         super.init()
     }
     
@@ -32,7 +33,6 @@ final class CompleteThunViewController: BaseViewController {
     }
 
     private let completeLabel = UILabel().then {
-        $0.text = "번개 신청을\n완료했어요!"
         $0.numberOfLines = 0
         $0.font = .pretendardRegular(size: 22)
         $0.textColor = .white
@@ -109,7 +109,7 @@ final class CompleteThunViewController: BaseViewController {
         $0.rowHeight = (UIScreen.main.bounds.height / 812) * 60
         $0.isScrollEnabled = false
     }
-
+    
     override func setupViews() {
         view.backgroundColor = .white
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: exitButton)

--- a/PlayTogether/PlayTogether/Sources/Home/View/CreateThunViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/View/CreateThunViewController.swift
@@ -694,7 +694,7 @@ final class CreateThunViewController: BaseViewController {
             .asDriver()
             .drive(onNext: { [weak self] in
                 self?.viewModel.createThunRequest(completion: { response in
-                    self?.navigationController?.pushViewController(CompleteThunViewController(lightID: response[0].id), animated: true)
+                    self?.navigationController?.pushViewController(CompleteThunViewController(lightID: response[0].id, completeText: "번개 오픈을\n완료했어요!"), animated: true)
                 })
             })
             .disposed(by: disposeBag)

--- a/PlayTogether/PlayTogether/Sources/Home/View/CreateThunViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/View/CreateThunViewController.swift
@@ -693,9 +693,9 @@ final class CreateThunViewController: BaseViewController {
         rightBarItem.rx.tap
             .asDriver()
             .drive(onNext: { [weak self] in
-                self?.viewModel.createThunRequest(completion: { response in
+                self?.viewModel.createThunRequest { response in
                     self?.navigationController?.pushViewController(CompleteThunViewController(lightID: response[0].id, completeText: "번개 오픈을\n완료했어요!"), animated: true)
-                })
+                }
             })
             .disposed(by: disposeBag)
     }

--- a/PlayTogether/PlayTogether/Sources/Home/View/CreateThunViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/View/CreateThunViewController.swift
@@ -694,7 +694,7 @@ final class CreateThunViewController: BaseViewController {
             .asDriver()
             .drive(onNext: { [weak self] in
                 self?.viewModel.createThunRequest(completion: { response in
-                    self?.navigationController?.pushViewController(CompleteThunViewController(), animated: true)
+                    self?.navigationController?.pushViewController(CompleteThunViewController(lightID: response[0].id), animated: true)
                 })
             })
             .disposed(by: disposeBag)

--- a/PlayTogether/PlayTogether/Sources/Home/View/CreateThunViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/View/CreateThunViewController.swift
@@ -693,9 +693,9 @@ final class CreateThunViewController: BaseViewController {
         rightBarItem.rx.tap
             .asDriver()
             .drive(onNext: { [weak self] in
-                self?.viewModel.createThunRequest() {
-                    self?.navigationController?.popViewController(animated: true)
-                }
+                self?.viewModel.createThunRequest(completion: { response in
+                    self?.navigationController?.pushViewController(CompleteThunViewController(), animated: true)
+                })
             })
             .disposed(by: disposeBag)
     }

--- a/PlayTogether/PlayTogether/Sources/Home/View/EnterDetailThunViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/View/EnterDetailThunViewController.swift
@@ -390,7 +390,7 @@ extension EnterDetailThunViewController: PopUpConfirmDelegate {
     func firstButtonDidTap() {}
     func secondButtonDidTap() {
         cancelViewModel.postCancelThun(lightId: lightId ?? -1) {_ in
-            self.navigationController?.pushViewController(CompleteThunViewController(lightID: self.lightId ?? -1), animated: true)
+            self.navigationController?.pushViewController(CompleteThunViewController(lightID: self.lightId ?? -1, completeText: "번개 신청을\n완료했어요!"), animated: true)
         }
     }
 }

--- a/PlayTogether/PlayTogether/Sources/Home/View/EnterDetailThunViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/View/EnterDetailThunViewController.swift
@@ -390,7 +390,10 @@ extension EnterDetailThunViewController: PopUpConfirmDelegate {
     func firstButtonDidTap() {}
     func secondButtonDidTap() {
         cancelViewModel.postCancelThun(lightId: lightId ?? -1) {_ in
-            self.navigationController?.pushViewController(CompleteThunViewController(lightID: self.lightId ?? -1, completeText: "번개 신청을\n완료했어요!"), animated: true)
+            self.navigationController?.pushViewController(CompleteThunViewController(
+                lightID: self.lightId ?? -1,
+                completeText: "번개 신청을\n완료했어요!"
+            ),animated: true)
         }
     }
 }

--- a/PlayTogether/PlayTogether/Sources/Home/ViewModel/CreateThunViewModel.swift
+++ b/PlayTogether/PlayTogether/Sources/Home/ViewModel/CreateThunViewModel.swift
@@ -46,7 +46,7 @@ final class CreateThunViewModel {
         return output
     }
     
-    func createThunRequest(completion: @escaping () -> Void) {
+    func createThunRequest(completion: @escaping ([CreateThun]) -> Void) {
         setupParameter()
         
         let provider = MoyaProvider<CreateThunService>()
@@ -55,8 +55,10 @@ final class CreateThunViewModel {
             params: parameter)
         ).subscribe { result in
             switch result {
-            case .success:
-                completion()
+            case let .success(response):
+                let responseData = try? response.map(CreateThunResponse.self)
+                guard let data = responseData?.data else { return }
+                completion(data)
             case let .failure(error):
                 print(error.localizedDescription)
             }


### PR DESCRIPTION
### 📌 이슈 번호
- #71

### 📌 작업 내역
- 번개 생성 완료 뷰에 서버를 연동합니다.
- 번개 신청과 번개 오픈 뷰 텍스트 나누기

### 📌 작업 결과 이미지 또는 영상
https://user-images.githubusercontent.com/53035245/188223075-f6d9bf3b-fdb0-4fc3-8f4e-ad4244b1eb27.mp4