### PR TITLE
[Feat] 온보딩 이동 로직 및 수정 사항 변경

### DIFF
--- a/PlayTogether/PlayTogether/Application/SceneDelegate.swift
+++ b/PlayTogether/PlayTogether/Application/SceneDelegate.swift
@@ -16,7 +16,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(windowScene: windowScene)
         window?.makeKeyAndVisible()
-        window?.rootViewController = TabBarController()
+//        window?.rootViewController = TabBarController()
+        window?.rootViewController = UINavigationController(rootViewController: OnboardingViewController())
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/PlayTogether/PlayTogether/Application/SceneDelegate.swift
+++ b/PlayTogether/PlayTogether/Application/SceneDelegate.swift
@@ -16,8 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(windowScene: windowScene)
         window?.makeKeyAndVisible()
-//        window?.rootViewController = TabBarController()
-        window?.rootViewController = UINavigationController(rootViewController: OnboardingViewController())
+        window?.rootViewController = TabBarController()
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {

--- a/PlayTogether/PlayTogether/Sources/Common/APIConstants.swift
+++ b/PlayTogether/PlayTogether/Sources/Common/APIConstants.swift
@@ -25,7 +25,6 @@ struct APIConstants {
     static let getLikedThunList = "/light"
     static let getDetailThunList = "/light/detail"
     static let postDetailThunCancel = "/light/enter"
-    static let existingNickname = "/user/crew"
     static let postLikeThun = "/scrap"
     static let getExistLikeThun = "/scrap/exist"
     static let postDeleteThun = "light/remove"
@@ -36,4 +35,5 @@ struct APIConstants {
     
     // user
     static let updateUserInfo = "/user/signup"
+    static let existingNickname = "/user/crew"
 }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceService.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceService.swift
@@ -30,7 +30,7 @@ extension SelfIntroduceService: TargetType {
             return APIConstants.getStationList
             
         case .existingNicknameRequset(let crewID, _):
-            return APIConstants.existingNickname + "/\(crewID)"
+            return APIConstants.existingNickname + "/\(crewID)/nickname"
         }
     }
     

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/CreateMeetViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/CreateMeetViewController.swift
@@ -182,8 +182,7 @@ class CreateMeetViewController: BaseViewController {
                 OnboardingDataModel.shared.meetingTitle = title
                 OnboardingDataModel.shared.introduceMessage = introduce
                 
-                let controller = InvitationCodeViewController()
-                self?.navigationController?.pushViewController(controller, animated: true)
+                self?.navigationController?.pushViewController(SelfIntroduceViewController(), animated: true)
             })
             .disposed(by: disposeBag)
         

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/OnboardingViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/OnboardingViewController.swift
@@ -55,7 +55,6 @@ class OnboardingViewController: BaseViewController {
     private let leftButtonItem = UIBarButtonItem(image: UIImage.ptImage(.backIcon), style: .plain, target: CheckTermsServiceViewController.self, action: nil)
 
     private let viewModel = OnboardingViewModel()
-    private lazy var cellIndex = 0
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -124,7 +123,9 @@ class OnboardingViewController: BaseViewController {
         nextButton.rx.tap
             .asDriver()
             .drive(onNext: { [weak self] in
-                self?.navigationController?.pushViewController(CreateMeetViewController(), animated: true)
+                guard let isCreate = OnboardingDataModel.shared.isCreated else { return }
+                let controller  = isCreate ? CreateMeetViewController() : InvitationCodeViewController()
+                self?.navigationController?.pushViewController(controller, animated: true)
             })
             .disposed(by: disposeBag)
     }
@@ -149,6 +150,6 @@ extension OnboardingViewController: UICollectionViewDelegate, UICollectionViewDa
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         nextButton.isButtonEnableUI(check: true)
-        cellIndex = indexPath.row
+        OnboardingDataModel.shared.isCreated = indexPath.row == 0 ? true : false
     }
 }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
@@ -372,9 +372,13 @@ class SelfIntroduceViewController: BaseViewController {
                 guard let nickname = self?.inputNicknameTextField.text,
                       let briefIntroduceText = self?.inputBriefIntroduceTextView.text
                 else { return }
+                // TODO: 선호하는 지하철역 1,2 추가예정
                 OnboardingDataModel.shared.nickName = nickname
                 OnboardingDataModel.shared.introduceSelfMessage = briefIntroduceText
-                // TODO: 다음 뷰로 넘어가는 기능 추가할 예정
+                
+                guard let isCreate = OnboardingDataModel.shared.isCreated else { return }
+                let controller = isCreate ? OpendThunViewController() : ParticipationCompletedViewController()
+                self?.navigationController?.pushViewController(controller, animated: true)
             })
             .disposed(by: disposeBag)
     }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
@@ -25,6 +25,7 @@ final class SelfIntroduceViewModel {
             .subscribe { result in
                 switch result {
                 case .success(let response):
+                    print(response)
                     let statusCode = response.statusCode
                     statusCode == 200 ? completion(true) : completion(false)
                 case .failure(let error):


### PR DESCRIPTION
### 📌 이슈 번호
- #85 

### 📌 작업 내역
* 개설 및 참여 따른 이동 경로를 바꿨습니다.
    * `OnboardingDataModel`을 통해 개설 및 참여 구분하여 로직 변경

* 닉네임 중복 확인 API 변경에 따른 Path 부분을 변경했습니다.

### 📌 작업 결과 이미지 또는 영상

https://user-images.githubusercontent.com/64394744/189045910-c6449cb2-e55e-48e1-9a6c-ba4cb3fed934.mp4
