### PR TITLE
[Feat] 온보딩 이동 로직 추가 및 지하철 추가 API 연동

### DIFF
--- a/PlayTogether/PlayTogether.xcodeproj/project.pbxproj
+++ b/PlayTogether/PlayTogether.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		B6B4B10728C1B5C7009AA0DB /* LogInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B4B10628C1B5C7009AA0DB /* LogInViewController.swift */; };
 		B6B7706128C1E16700645DCB /* LoginButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B7706028C1E16700645DCB /* LoginButtonView.swift */; };
 		B6C543FE28939E2B00E86736 /* CreateMeetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C543FD28939E2B00E86736 /* CreateMeetViewModel.swift */; };
+		B6DFD6DC294448C700561872 /* SelfIntroduceResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6DFD6DB294448C700561872 /* SelfIntroduceResponse.swift */; };
 		B6E8851128C05D9C001CAE3D /* ReDownloadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E8851028C05D9C001CAE3D /* ReDownloadViewController.swift */; };
 		B6ECF18B28B5BAB9003C80AB /* ParticipationCompletedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ECF18A28B5BAB9003C80AB /* ParticipationCompletedViewController.swift */; };
 		B6ECF18F28B5C795003C80AB /* UILabel+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6ECF18E28B5C795003C80AB /* UILabel+Extension.swift */; };
@@ -262,6 +263,7 @@
 		B6B4B10628C1B5C7009AA0DB /* LogInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogInViewController.swift; sourceTree = "<group>"; };
 		B6B7706028C1E16700645DCB /* LoginButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginButtonView.swift; sourceTree = "<group>"; };
 		B6C543FD28939E2B00E86736 /* CreateMeetViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetViewModel.swift; sourceTree = "<group>"; };
+		B6DFD6DB294448C700561872 /* SelfIntroduceResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfIntroduceResponse.swift; sourceTree = "<group>"; };
 		B6E8851028C05D9C001CAE3D /* ReDownloadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReDownloadViewController.swift; sourceTree = "<group>"; };
 		B6ECF18A28B5BAB9003C80AB /* ParticipationCompletedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipationCompletedViewController.swift; sourceTree = "<group>"; };
 		B6ECF18E28B5C795003C80AB /* UILabel+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+Extension.swift"; sourceTree = "<group>"; };
@@ -770,6 +772,7 @@
 				B66EA07B28A7E60B00F1F723 /* SubwayStationResponse.swift */,
 				B6A612FE28A9F36600688DA2 /* CheckNicknameResponse.swift */,
 				B6B4B10228C1AE3C009AA0DB /* FetchMeetingService.swift */,
+				B6DFD6DB294448C700561872 /* SelfIntroduceResponse.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1062,6 +1065,7 @@
 				B6720EE328D2EC7A00E34EA1 /* Element+Extension.swift in Sources */,
 				B66EA07A28A7E5C800F1F723 /* SelfIntroduceViewModel.swift in Sources */,
 				40B15BFB28C04C8E00E2CB82 /* MessageListResponse.swift in Sources */,
+				B6DFD6DC294448C700561872 /* SelfIntroduceResponse.swift in Sources */,
 				B6ECF18F28B5C795003C80AB /* UILabel+Extension.swift in Sources */,
 				4096A29C287F5F3F00F1E27C /* SceneDelegate.swift in Sources */,
 				B61C427028A20CA800913574 /* SelfIntroduceViewController.swift in Sources */,

--- a/PlayTogether/PlayTogether/Sources/Common/APIConstants.swift
+++ b/PlayTogether/PlayTogether/Sources/Common/APIConstants.swift
@@ -56,6 +56,7 @@ struct APIConstants {
     // user
     static let updateUserInfo = "/user/signup"
     static let existingNickname = "/user/crew"
+    static let putRegisterUserSubway = "/user"
     
     // auth
     static let deleteAccount = "/auth/withdraw"

--- a/PlayTogether/PlayTogether/Sources/LogIn/Controller/LogInViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/LogIn/Controller/LogInViewController.swift
@@ -137,7 +137,9 @@ private extension LogInViewController {
             guard loggedInUserInfo.isSignup == true else {
                 guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate
                         as? SceneDelegate else { return }
-                sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: OnboardingViewController())
+                sceneDelegate.window?.rootViewController = UINavigationController(
+                    rootViewController: CheckTermsServiceViewController()
+                )
                 return
             }
             // TODO: 키체인 변경 예정

--- a/PlayTogether/PlayTogether/Sources/LogIn/Controller/LogInViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/LogIn/Controller/LogInViewController.swift
@@ -123,8 +123,12 @@ extension LogInViewController: LoginButtonDelegate {
     }
 }
 
-extension LogInViewController {
-    func requestLogin(accessToken: String, fcmToken: String) {
+private extension LogInViewController {
+    func requestLogin(accessToken: String?, fcmToken: String?) {
+        guard let accessToken = accessToken,
+              let fcmToken = fcmToken
+        else { return }
+
         let loginInput = LoginViewModel.loginTokenInput(accessToken: accessToken,
                                                         fcmToken: fcmToken)
         viewModel.tryLogin(loginInput) {
@@ -154,19 +158,19 @@ private extension LogInViewController {
     func kakaoLogin() {
         guard UserApi.isKakaoTalkLoginAvailable() == true else {
             UserApi.shared.loginWithKakaoAccount(prompts:[.Login]) { oauthToken, error  in
-                guard let accessToken = oauthToken?.accessToken else { return }
-                guard let fcmToken = self.userFCMToken else { return }
-                self.userAccessToken = accessToken
-                self.requestLogin(accessToken: accessToken, fcmToken: fcmToken)
+                self.requestLogin(
+                    accessToken: oauthToken?.accessToken,
+                    fcmToken: self.userFCMToken
+                )
             }
             return
         }
         
         UserApi.shared.loginWithKakaoTalk { oauthToken, error in
-            guard let accessToken = oauthToken?.accessToken else { return }
-            guard let fcmToken = self.userFCMToken else { return }
-            self.userAccessToken = accessToken
-            self.requestLogin(accessToken: accessToken, fcmToken: fcmToken)
+            self.requestLogin(
+                accessToken: oauthToken?.accessToken,
+                fcmToken: self.userFCMToken
+            )
         }
     }
 }
@@ -188,8 +192,10 @@ extension LogInViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
         switch authorization.credential {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
             let token = String(data: appleIDCredential.identityToken!, encoding: .utf8)
-            // TODO: 로그인 API 추후 연동 예정
-            print("DEBUG: apple login token  → \(token)")
+            self.requestLogin(
+                accessToken: token,
+                fcmToken: self.userFCMToken
+            )
             
         default: break
         }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceResponse.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceResponse.swift
@@ -1,0 +1,24 @@
+//
+//  SelfIntroduceResponse.swift
+//  PlayTogether
+//
+//  Created by 이지석 on 2022/12/10.
+//
+
+struct SelfIntroduceResponse: Codable {
+    let status: Int
+    let success: Bool
+    let message: String
+    let data: RegisterUserSubwayData
+}
+
+struct RegisterUserSubwayData: Codable {
+    let nickname, dataDescription, firstStation: String
+    let secondStation: String?
+
+    enum CodingKeys: String, CodingKey {
+        case nickname
+        case dataDescription = "description"
+        case firstStation, secondStation
+    }
+}

--- a/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceService.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceService.swift
@@ -11,6 +11,13 @@ import Foundation
 enum SelfIntroduceService {
     case searchStationRequeset
     case existingNicknameRequset(crewID: Int, Nickname: String)
+    case registerUserSubwayStations(
+        crewID: Int,
+        nickName: String,
+        description: String,
+        firstSubway: String,
+        secondSubway: String? = nil
+    )
 }
 
 extension SelfIntroduceService: TargetType {
@@ -19,7 +26,8 @@ extension SelfIntroduceService: TargetType {
         case .searchStationRequeset:
             return URL(string: APIConstants.subwayBaseUrl)!
             
-        case .existingNicknameRequset:
+        case .existingNicknameRequset,
+             .registerUserSubwayStations:
             return URL(string: APIConstants.baseUrl)!
         }
     }
@@ -31,6 +39,10 @@ extension SelfIntroduceService: TargetType {
             
         case .existingNicknameRequset(let crewID, _):
             return APIConstants.existingNickname + "/\(crewID)/nickname"
+            
+        case .registerUserSubwayStations(let crewID, _, _, _, _):
+            return APIConstants.putRegisterUserSubway + "\(crewID)"
+            
         }
     }
     
@@ -46,6 +58,15 @@ extension SelfIntroduceService: TargetType {
         case .existingNicknameRequset(_, let nickname):
             let param = [
                 "nickname" : nickname
+            ]
+            return .requestParameters(parameters: param, encoding: URLEncoding.queryString)
+            
+        case .registerUserSubwayStations(_, let nickName, let description, let firstSubway, let secondSubway):
+            let param: [String : Any] = [
+                "nickname" : nickName,
+                "description" : description,
+                "firstSubway" : firstSubway,
+                "secondSubway" : secondSubway as Any
             ]
             return .requestParameters(parameters: param, encoding: URLEncoding.queryString)
         }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/AddSubwayStationViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/AddSubwayStationViewController.swift
@@ -9,6 +9,10 @@ import UIKit
 import RxSwift
 import RxCocoa
 
+protocol AddSubwayStationDelegate {
+    func registerSubwayStation(_ stations: [String])
+}
+
 class AddSubwayStationViewController: BaseViewController {
     private let disposeBag = DisposeBag()
     private let viewModel = AddSubwayStationViewModel()
@@ -91,6 +95,7 @@ class AddSubwayStationViewController: BaseViewController {
     private lazy var selectedSubwayStations = [String]()
     private var selectedSubwayStationRelay = BehaviorRelay<[String]>(value: [])
     private var collectionViewHeight: CGFloat = 0
+    var delegate: AddSubwayStationDelegate?
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -260,6 +265,7 @@ class AddSubwayStationViewController: BaseViewController {
             .drive(onNext: { [weak self] _ in
                 guard let self = self else { return }
                 OnboardingDataModel.shared.preferredSubway = self.selectedSubwayStations
+                self.delegate?.registerSubwayStation(self.selectedSubwayStations)
                 self.navigationController?.popViewController(animated: true)
             })
             .disposed(by: disposeBag)

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
@@ -13,6 +13,7 @@ import RxMoya
 
 final class SelfIntroduceViewModel {
     private lazy var disposeBag = DisposeBag()
+    private let provider = MoyaProvider<SelfIntroduceService>()
     
     struct checkNicknameInput {
         var crewID: Int
@@ -20,7 +21,6 @@ final class SelfIntroduceViewModel {
     }
     
     func checkNickname(_ crewId: Int, _ nickName: String, completion: @escaping (Bool) -> Void) {
-        let provider = MoyaProvider<SelfIntroduceService>()
         provider.rx.request(.existingNicknameRequset(crewID: crewId, Nickname: nickName))
             .subscribe { result in
                 switch result {
@@ -33,5 +33,33 @@ final class SelfIntroduceViewModel {
                 }
             }
             .disposed(by: disposeBag)
+    }
+    
+    func registerUserProfile(
+        _ crewId: Int,
+        _ nickName: String,
+        _ description: String,
+        _ firstSubway: String,
+        _ secondSubway: String? = nil,
+        completion: @escaping (Bool) -> Void) {
+        provider.rx.request(
+            .registerUserSubwayStations(
+                crewID: crewId,
+                nickName: nickName,
+                description: description,
+                firstSubway: firstSubway,
+                secondSubway: secondSubway)
+        ).subscribe { result in
+            switch result {
+            case .success(let response):
+                guard let responseData = try? response.map(SelfIntroduceResponse.self)
+                else { return }
+                completion(responseData.status == 200)
+                
+            case .failure(let error):
+                print(error.localizedDescription)
+            }
+        }
+        .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
### 📌 이슈 번호
- #36 

### 📌 작업 내역
- 불필요한 코드 제거
    - `.requestLogin` Optional  binding
- 각각의 기능 분기처리
    - Apple Login → Login API 연동
    - 로그인 후 회원가입 하지 않은 유저 이용약관 뷰로 이동
- 유저 지하철역 추가 API 연동
