### PR TITLE
[Feat] 소셜 로그인 및 로그인 API 연동

### DIFF
--- a/PlayTogether/PlayTogether/Resources/Info.plist
+++ b/PlayTogether/PlayTogether/Resources/Info.plist
@@ -47,9 +47,11 @@
 		<string>fetch</string>
 		<string>remote-notification</string>
 	</array>
-	<key>UIStatusBarStyle</key>
-	<string>UIStatusBarStyleLightContent</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+	</array>
 </dict>
 </plist>

--- a/PlayTogether/PlayTogether/Sources/LogIn/Controller/LogInViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/LogIn/Controller/LogInViewController.swift
@@ -11,6 +11,11 @@ import KakaoSDKAuth
 import KakaoSDKUser
 import AuthenticationServices
 
+enum SocialLoginType {
+    case KakaoLogin
+    case AppleLogin
+}
+
 class LogInViewController: BaseViewController {
     private lazy var disposeBag = DisposeBag()
     
@@ -124,14 +129,17 @@ extension LogInViewController: LoginButtonDelegate {
 }
 
 private extension LogInViewController {
-    func requestLogin(accessToken: String?, fcmToken: String?) {
+    func requestLogin(accessToken: String?, fcmToken: String?, type: SocialLoginType) {
         guard let accessToken = accessToken,
               let fcmToken = fcmToken
         else { return }
 
         let loginInput = LoginViewModel.loginTokenInput(accessToken: accessToken,
                                                         fcmToken: fcmToken)
-        viewModel.tryLogin(loginInput) {
+        viewModel.socialLoginRequest(
+            input: loginInput,
+            type: type
+        ) {
             guard $0.status == 200 else { return }
             let loggedInUserInfo = $0.data
             guard loggedInUserInfo.isSignup == true else {
@@ -162,7 +170,8 @@ private extension LogInViewController {
             UserApi.shared.loginWithKakaoAccount(prompts:[.Login]) { oauthToken, error  in
                 self.requestLogin(
                     accessToken: oauthToken?.accessToken,
-                    fcmToken: self.userFCMToken
+                    fcmToken: self.userFCMToken,
+                    type: .KakaoLogin
                 )
             }
             return
@@ -171,7 +180,8 @@ private extension LogInViewController {
         UserApi.shared.loginWithKakaoTalk { oauthToken, error in
             self.requestLogin(
                 accessToken: oauthToken?.accessToken,
-                fcmToken: self.userFCMToken
+                fcmToken: self.userFCMToken,
+                type: .KakaoLogin
             )
         }
     }
@@ -196,7 +206,8 @@ extension LogInViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
             let token = String(data: appleIDCredential.identityToken!, encoding: .utf8)
             self.requestLogin(
                 accessToken: token,
-                fcmToken: self.userFCMToken
+                fcmToken: self.userFCMToken,
+                type: .AppleLogin
             )
             
         default: break

--- a/PlayTogether/PlayTogether/Sources/LogIn/Controller/LogInViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/LogIn/Controller/LogInViewController.swift
@@ -142,7 +142,7 @@ private extension LogInViewController {
         ) {
             guard $0.status == 200 else { return }
             let loggedInUserInfo = $0.data
-            guard loggedInUserInfo.isSignup == true else {
+            guard loggedInUserInfo?.isSignup == true else {
                 guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate
                         as? SceneDelegate else { return }
                 sceneDelegate.window?.rootViewController = UINavigationController(
@@ -151,9 +151,9 @@ private extension LogInViewController {
                 return
             }
             // TODO: 키체인 변경 예정
-            UserDefaults.standard.set(loggedInUserInfo.accessToken, forKey: "accessToken")
-            UserDefaults.standard.set(loggedInUserInfo.refreshToken, forKey: "refreshToken")
-            UserDefaults.standard.set(loggedInUserInfo.userName, forKey: "userName")
+            UserDefaults.standard.set(loggedInUserInfo?.accessToken, forKey: "accessToken")
+            UserDefaults.standard.set(loggedInUserInfo?.refreshToken, forKey: "refreshToken")
+            UserDefaults.standard.set(loggedInUserInfo?.userName, forKey: "userName")
             
             guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate
                     as? SceneDelegate else { return }

--- a/PlayTogether/PlayTogether/Sources/LogIn/Network/LoginResponse.swift
+++ b/PlayTogether/PlayTogether/Sources/LogIn/Network/LoginResponse.swift
@@ -9,7 +9,7 @@ struct LoginResponse: Codable {
     let status: Int
     let success: Bool
     let message: String
-    let data: LoginUserInfo
+    let data: LoginUserInfo?
 }
 
 struct LoginUserInfo: Codable {

--- a/PlayTogether/PlayTogether/Sources/LogIn/Network/LoginService.swift
+++ b/PlayTogether/PlayTogether/Sources/LogIn/Network/LoginService.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum LoginService {
     case kakaoLoginReuest(accessToken: String, fcmToken: String)
-    case appleLoginReuset
+    case appleLoginReuset(accessToken: String, fcmToken: String)
 }
 
 extension LoginService: TargetType {
@@ -45,11 +45,11 @@ extension LoginService: TargetType {
                 "fcmToken": fcmToken
             ]
             
-        case .appleLoginReuset:
+        case .appleLoginReuset(let accessToken, let fcmToken):
             return [
                 "Content-Type": "application/json",
-                "accessToken" : "",
-                "fcmToken": ""
+                "accessToken" : accessToken,
+                "fcmToken": fcmToken
             ]
         }
     }

--- a/PlayTogether/PlayTogether/Sources/LogIn/ViewModel/LoginViewModel.swift
+++ b/PlayTogether/PlayTogether/Sources/LogIn/ViewModel/LoginViewModel.swift
@@ -10,27 +10,53 @@ import Moya
 
 final class LoginViewModel {
     private lazy var disposeBag = DisposeBag()
+    private let provider = MoyaProvider<LoginService>()
     
     struct loginTokenInput {
         var accessToken: String
         var fcmToken: String
     }
     
-    func tryLogin(_ input: loginTokenInput, completion: @escaping (LoginResponse) -> Void) {
-        let provider = MoyaProvider<LoginService>()
-        provider.rx.request(.kakaoLoginReuest(accessToken: input.accessToken,
-                                              fcmToken: input.fcmToken))
-        .subscribe { result in
-            switch result {
-            case .success(let response):
-                let responseData = try? response.map(LoginResponse.self)
-                guard let userInfo = responseData else { return }
-                completion(userInfo)
-                
-            case .failure(let error):
-                print(error.localizedDescription)
+    func socialLoginRequest(
+        input: loginTokenInput,
+        type: SocialLoginType,
+        completion: @escaping (LoginResponse) -> Void
+    ) {
+        switch type {
+        case .KakaoLogin:
+            provider.rx.request(.kakaoLoginReuest(
+                accessToken: input.accessToken,
+                fcmToken: input.fcmToken
+            )).subscribe { result in
+                switch result {
+                case .success(let response):
+                    let responseData = try? response.map(LoginResponse.self)
+                    guard let userInfo = responseData else { return }
+                    completion(userInfo)
+                    
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
             }
+            .disposed(by: disposeBag)
+            
+        case .AppleLogin:
+            provider.rx.request(.appleLoginReuset(
+                accessToken: input.accessToken,
+                fcmToken: input.fcmToken
+            )).subscribe { result in
+                switch result {
+                case .success(let response):
+                    let responseData = try? response.map(LoginResponse.self)
+                    guard let userInfo = responseData else { return }
+                    completion(userInfo)
+                    
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+            .disposed(by: disposeBag)
         }
-        .disposed(by: disposeBag)
     }
+    
 }


### PR DESCRIPTION
### 📌 이슈 번호
- #102 

### 📌 작업 내역
- 소셜 로그인 중 카카오 로그인 관련해서 카카오톡이 설치 되어 있으면 카카오톡으로 로그인 진행하는 코드가 실행이 되지 않았는데, 해당 부분 Info.plist 설정으로 수정 완료
- 로그인 API 호출 시 소셜 로그인 case 분기 처리
- LoginInfoModel 옵셔널 처리 → nullable 변수 확인