### PR TITLE
[Feat] 동아리 생성 API 연동

### DIFF
--- a/PlayTogether/PlayTogether.xcodeproj/project.pbxproj
+++ b/PlayTogether/PlayTogether.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		40EE01C728BFD4B500DE46C8 /* ChattingRoomTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40EE01C628BFD4B500DE46C8 /* ChattingRoomTableViewCell.swift */; };
 		40F7FE2828BF497A00B58A4C /* ChattingListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F7FE2728BF497A00B58A4C /* ChattingListTableViewCell.swift */; };
 		48C57D10299494420026BD79 /* CreateMeetService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C57D0F299494420026BD79 /* CreateMeetService.swift */; };
+		48C57D12299496580026BD79 /* CreateMeetResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C57D11299496580026BD79 /* CreateMeetResponse.swift */; };
 		B6105B7F28AC8E9000DB4BAC /* AddSubwayStationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6105B7E28AC8E9000DB4BAC /* AddSubwayStationViewController.swift */; };
 		B616A80F2886A21C00E1ABCF /* OnboardingDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B616A80E2886A21C00E1ABCF /* OnboardingDataModel.swift */; };
 		B616A8152886A96300E1ABCF /* CreateMeetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B616A8142886A96300E1ABCF /* CreateMeetViewController.swift */; };
@@ -230,6 +231,7 @@
 		40EE01C628BFD4B500DE46C8 /* ChattingRoomTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingRoomTableViewCell.swift; sourceTree = "<group>"; };
 		40F7FE2728BF497A00B58A4C /* ChattingListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingListTableViewCell.swift; sourceTree = "<group>"; };
 		48C57D0F299494420026BD79 /* CreateMeetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetService.swift; sourceTree = "<group>"; };
+		48C57D11299496580026BD79 /* CreateMeetResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetResponse.swift; sourceTree = "<group>"; };
 		B6105B7E28AC8E9000DB4BAC /* AddSubwayStationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSubwayStationViewController.swift; sourceTree = "<group>"; };
 		B616A80E2886A21C00E1ABCF /* OnboardingDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDataModel.swift; sourceTree = "<group>"; };
 		B616A8142886A96300E1ABCF /* CreateMeetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetViewController.swift; sourceTree = "<group>"; };
@@ -776,6 +778,7 @@
 				B6B4B10228C1AE3C009AA0DB /* FetchMeetingService.swift */,
 				B6DFD6DB294448C700561872 /* SelfIntroduceResponse.swift */,
 				48C57D0F299494420026BD79 /* CreateMeetService.swift */,
+				48C57D11299496580026BD79 /* CreateMeetResponse.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1015,6 +1018,7 @@
 				408EE3E928BAB2510012C642 /* MyPageViewModel.swift in Sources */,
 				DDAE9DBB290E591C0021FBEA /* DeleteAccountViewController.swift in Sources */,
 				DDB380D528C08E73001826B0 /* DeleteThunViewModel.swift in Sources */,
+				48C57D12299496580026BD79 /* CreateMeetResponse.swift in Sources */,
 				402A16EC28C4D49100161820 /* CompleteURLLoggerPlugin.swift in Sources */,
 				DDB380ED28C27C86001826B0 /* CreateThunResponse.swift in Sources */,
 				40727C1628A1B635007E5835 /* UIResponder+Extension.swift in Sources */,

--- a/PlayTogether/PlayTogether.xcodeproj/project.pbxproj
+++ b/PlayTogether/PlayTogether.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		40EE01C528BFD46700DE46C8 /* ChattingRoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40EE01C428BFD46700DE46C8 /* ChattingRoomViewModel.swift */; };
 		40EE01C728BFD4B500DE46C8 /* ChattingRoomTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40EE01C628BFD4B500DE46C8 /* ChattingRoomTableViewCell.swift */; };
 		40F7FE2828BF497A00B58A4C /* ChattingListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F7FE2728BF497A00B58A4C /* ChattingListTableViewCell.swift */; };
+		48C57D10299494420026BD79 /* CreateMeetService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C57D0F299494420026BD79 /* CreateMeetService.swift */; };
 		B6105B7F28AC8E9000DB4BAC /* AddSubwayStationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6105B7E28AC8E9000DB4BAC /* AddSubwayStationViewController.swift */; };
 		B616A80F2886A21C00E1ABCF /* OnboardingDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B616A80E2886A21C00E1ABCF /* OnboardingDataModel.swift */; };
 		B616A8152886A96300E1ABCF /* CreateMeetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B616A8142886A96300E1ABCF /* CreateMeetViewController.swift */; };
@@ -228,6 +229,7 @@
 		40EE01C428BFD46700DE46C8 /* ChattingRoomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingRoomViewModel.swift; sourceTree = "<group>"; };
 		40EE01C628BFD4B500DE46C8 /* ChattingRoomTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingRoomTableViewCell.swift; sourceTree = "<group>"; };
 		40F7FE2728BF497A00B58A4C /* ChattingListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChattingListTableViewCell.swift; sourceTree = "<group>"; };
+		48C57D0F299494420026BD79 /* CreateMeetService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetService.swift; sourceTree = "<group>"; };
 		B6105B7E28AC8E9000DB4BAC /* AddSubwayStationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSubwayStationViewController.swift; sourceTree = "<group>"; };
 		B616A80E2886A21C00E1ABCF /* OnboardingDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingDataModel.swift; sourceTree = "<group>"; };
 		B616A8142886A96300E1ABCF /* CreateMeetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateMeetViewController.swift; sourceTree = "<group>"; };
@@ -773,6 +775,7 @@
 				B6A612FE28A9F36600688DA2 /* CheckNicknameResponse.swift */,
 				B6B4B10228C1AE3C009AA0DB /* FetchMeetingService.swift */,
 				B6DFD6DB294448C700561872 /* SelfIntroduceResponse.swift */,
+				48C57D0F299494420026BD79 /* CreateMeetService.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1025,6 +1028,7 @@
 				B616A80F2886A21C00E1ABCF /* OnboardingDataModel.swift in Sources */,
 				4066E49A288B3CF700FC9090 /* CALayer+Extension.swift in Sources */,
 				402A16EA28C4C5F800161820 /* BottomSheetTableViewCell.swift in Sources */,
+				48C57D10299494420026BD79 /* CreateMeetService.swift in Sources */,
 				DD0EBE2C28D9D74A00A50CDB /* ReportCompleteThunViewController.swift in Sources */,
 				B6AA809A28B0AE2200F29B59 /* SubwayStationListTableViewCell.swift in Sources */,
 				409451B328905D7D00F21717 /* HomeResponse.swift in Sources */,

--- a/PlayTogether/PlayTogether/Sources/Common/APIConstants.swift
+++ b/PlayTogether/PlayTogether/Sources/Common/APIConstants.swift
@@ -42,6 +42,7 @@ struct APIConstants {
     static let getEatGoDoThunList = "light/\(crewID)"
     static let getSearchThun = "light/\(crewID)/search"
     static let postReportThun = "light/report"
+    static let postCreateMeet = "/crew"
     
     // login
     static let kakaoLogin = "/auth/kakao-login"

--- a/PlayTogether/PlayTogether/Sources/LogIn/Controller/LogInViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/LogIn/Controller/LogInViewController.swift
@@ -142,6 +142,11 @@ private extension LogInViewController {
         ) {
             guard $0.status == 200 else { return }
             let loggedInUserInfo = $0.data
+            
+            UserDefaults.standard.set(loggedInUserInfo?.accessToken, forKey: "accessToken")
+            UserDefaults.standard.set(loggedInUserInfo?.refreshToken, forKey: "refreshToken")
+            UserDefaults.standard.set(loggedInUserInfo?.userName, forKey: "userName")
+            
             guard loggedInUserInfo?.isSignup == true else {
                 guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate
                         as? SceneDelegate else { return }
@@ -150,10 +155,6 @@ private extension LogInViewController {
                 )
                 return
             }
-            // TODO: 키체인 변경 예정
-            UserDefaults.standard.set(loggedInUserInfo?.accessToken, forKey: "accessToken")
-            UserDefaults.standard.set(loggedInUserInfo?.refreshToken, forKey: "refreshToken")
-            UserDefaults.standard.set(loggedInUserInfo?.userName, forKey: "userName")
             
             guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate
                     as? SceneDelegate else { return }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/Network/CreateMeetResponse.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/Network/CreateMeetResponse.swift
@@ -1,0 +1,18 @@
+//
+//  CreateMeetResponse.swift
+//  PlayTogether
+//
+//  Created by 이지석 on 2023/02/09.
+//
+
+struct CreateMeetResponse: Codable {
+    let status: Int
+    let success: Bool
+    let message: String
+    let data: CreateMeetData?
+}
+
+struct CreateMeetData: Codable {
+    let id: Int
+    let name, code, description: String
+}

--- a/PlayTogether/PlayTogether/Sources/Onboarding/Network/CreateMeetService.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/Network/CreateMeetService.swift
@@ -32,7 +32,7 @@ extension CreateMeetService: TargetType {
                 "crewName": crewName,
                 "description": description
             ]
-            return .requestParameters(parameters: param, encoding: URLEncoding.queryString)
+            return .requestParameters(parameters: param, encoding: JSONEncoding.default)
         }
         
     }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/Network/CreateMeetService.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/Network/CreateMeetService.swift
@@ -1,0 +1,49 @@
+//
+//  CreateMeetService.swift
+//  PlayTogether
+//
+//  Created by 이지석 on 2023/02/09.
+//
+
+import Moya
+import Foundation
+
+enum CreateMeetService {
+    case createMeetRequest(crewName: String, description: String, jwt: String)
+}
+
+extension CreateMeetService: TargetType {
+    var baseURL: URL {
+        return URL(string: APIConstants.baseUrl)!
+    }
+    
+    var path: String {
+        return APIConstants.postCreateMeet
+    }
+    
+    var method: Moya.Method {
+        return .post
+    }
+    
+    var task: Task {
+        switch self {
+        case .createMeetRequest(let crewName, let description, _):
+            let param: [String : Any] = [
+                "crewName": crewName,
+                "description": description
+            ]
+            return .requestParameters(parameters: param, encoding: URLEncoding.queryString)
+        }
+        
+    }
+    
+    var headers: [String : String]? {
+        switch self {
+        case .createMeetRequest(_, _, let jwt):
+            return [
+                "Content-Type": "application/json",
+                "Authorization": jwt
+            ]
+        }
+    }
+}

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/CreateMeetViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/CreateMeetViewController.swift
@@ -177,10 +177,21 @@ class CreateMeetViewController: BaseViewController {
         nextButton.rx.tap
             .asDriver()
             .drive(onNext: { [weak self] in
-                guard let title = self?.titleTextField.text else { return }
-                guard let introduce = self?.introduceTextField.text else { return }
+                guard let title = self?.titleTextField.text,
+                      let introduce = self?.introduceTextField.text
+                else { return }
+                
                 OnboardingDataModel.shared.meetingTitle = title
                 OnboardingDataModel.shared.introduceMessage = introduce
+                
+                let requestInput = CreateMeetViewModel.CreateMeetInput(
+                    crewName: title,
+                    description: introduce,
+                    jwt: UserDefaults.standard.string(forKey: "accessToken") ?? ""
+                )
+                self?.viewModel.createMeetRequest(requestInput) { response in
+                    print("DEBUG: from ViewController → \(response)")
+                }
                 
                 self?.navigationController?.pushViewController(SelfIntroduceViewController(), animated: true)
             })

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/CreateMeetViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/CreateMeetViewController.swift
@@ -177,6 +177,11 @@ class CreateMeetViewController: BaseViewController {
         nextButton.rx.tap
             .asDriver()
             .drive(onNext: { [weak self] in
+                guard OnboardingDataModel.shared.madeCrew == false else {
+                    self?.navigationController?.pushViewController(SelfIntroduceViewController(), animated: true)
+                    return
+                }
+                
                 guard let title = self?.titleTextField.text,
                       let introduce = self?.introduceTextField.text
                 else { return }
@@ -190,10 +195,11 @@ class CreateMeetViewController: BaseViewController {
                     jwt: UserDefaults.standard.string(forKey: "accessToken") ?? ""
                 )
                 self?.viewModel.createMeetRequest(requestInput) { response in
-                    print("DEBUG: from ViewController → \(response)")
+                    OnboardingDataModel.shared.crewId = response.data?.id
+                    OnboardingDataModel.shared.madeCrew = response.success
+                    self?.navigationController?.pushViewController(SelfIntroduceViewController(), animated: true)
                 }
-                
-                self?.navigationController?.pushViewController(SelfIntroduceViewController(), animated: true)
+                // FIXME: 동아리 만드는 오류 팝업 띄어주기 에러 참조
             })
             .disposed(by: disposeBag)
         

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
@@ -387,7 +387,7 @@ class SelfIntroduceViewController: BaseViewController {
                 
                 let controller = isCreate ? OpendThunViewController() : ParticipationCompletedViewController()
                 self.viewModel.registerUserProfile(
-                    33,           // TODO: 추후 동아리 번호 받아올 예정
+                    OnboardingDataModel.shared.crewId ?? -1,
                     nickname,
                     briefIntroduceText,
                     self.registerUserStations.value.first!,

--- a/PlayTogether/PlayTogether/Utils/OnboardingDataModel.swift
+++ b/PlayTogether/PlayTogether/Utils/OnboardingDataModel.swift
@@ -16,5 +16,8 @@ class OnboardingDataModel {
     var introduceSelfMessage: String?
     var preferredSubway: [String]?
     
+    var crewId: Int?
+    var madeCrew: Bool?
+    
     private init() {}
 }


### PR DESCRIPTION
### 📌 이슈 번호
- #122 

### 📌 작업 내역
- 동아리 생성 API 연동
- CreateMeet 관련 Network, response 파일 생성
- CreateMeetViewModel → Input, function 생성
- 로그인 했을 시 토큰 값 저장하는 코드가 `guard`문 이후에 `return`을 통해 저장되기 전에 반환되고 있어서 해당 저장 코드 위치 변경
- 동아리를 만들고 이전으로 돌아갔다가 다시 만들기 누르면 기존 정보 그대로 새로운 동아리가 만들어져서 해당 부분 방어 코드 추가 → `OnboardingDataModel.shared.madeCrew`
- 다음 자기소개 뷰에 필요한 동아리 정보(`crewId`) 바인딩 가능하도록 `OnboardingDataModel` 요소 추가

### 📌 작업 결과 이미지 또는 영상
<img width="218" alt="동아리만들기" src="https://user-images.githubusercontent.com/64394744/217742128-0693e839-0782-432c-abc4-673f80705f2a.png">