### PR TITLE
[Feat] 온보딩 전체 로직 체크 및 리펙토링(1)

### DIFF
--- a/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceResponse.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceResponse.swift
@@ -9,12 +9,12 @@ struct SelfIntroduceResponse: Codable {
     let status: Int
     let success: Bool
     let message: String
-    let data: RegisterUserSubwayData
+    let data: RegisterUserSubwayData?
 }
 
 struct RegisterUserSubwayData: Codable {
-    let nickname, dataDescription, firstStation: String
-    let secondStation: String?
+    let nickname, dataDescription: String
+    let firstStation, secondStation: String?
 
     enum CodingKeys: String, CodingKey {
         case nickname

--- a/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceService.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceService.swift
@@ -41,13 +41,20 @@ extension SelfIntroduceService: TargetType {
             return APIConstants.existingNickname + "/\(crewID)/nickname"
             
         case .registerUserSubwayStations(let crewID, _, _, _, _):
-            return APIConstants.putRegisterUserSubway + "\(crewID)"
+            return APIConstants.putRegisterUserSubway + "/\(crewID)"
             
         }
     }
     
     var method: Moya.Method {
-        return .get
+        switch self {
+        case .searchStationRequeset,
+             .existingNicknameRequset:
+            return .get
+            
+        case .registerUserSubwayStations:
+            return .put
+        }
     }
     
     var task: Task {
@@ -62,19 +69,38 @@ extension SelfIntroduceService: TargetType {
             return .requestParameters(parameters: param, encoding: URLEncoding.queryString)
             
         case .registerUserSubwayStations(_, let nickName, let description, let firstSubway, let secondSubway):
+            guard let secondSubway = secondSubway else {
+                let param: [String : Any] = [
+                    "nickname" : nickName,
+                    "description" : description,
+                    "firstSubway" : firstSubway
+                ]
+                return .requestParameters(parameters: param, encoding: JSONEncoding.default)
+            }
             let param: [String : Any] = [
                 "nickname" : nickName,
                 "description" : description,
                 "firstSubway" : firstSubway,
-                "secondSubway" : secondSubway as Any
+                "secondSubway" : secondSubway
             ]
-            return .requestParameters(parameters: param, encoding: URLEncoding.queryString)
+            return .requestParameters(parameters: param, encoding: JSONEncoding.default)
         }
     }
     
     var headers: [String : String]? {
-        return [
-            "Content-Type": "application/json"
-        ]
+        switch self {
+        case .searchStationRequeset,
+                .existingNicknameRequset:
+            return [
+                "Content-Type": "application/json"
+            ]
+            
+        case .registerUserSubwayStations:
+            let jwt = UserDefaults.standard.string(forKey: "accessToken") ?? ""
+            return [
+                "Content-Type": "application/json",
+                "Authorization" : jwt
+            ]
+        }
     }   
 }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceService.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceService.swift
@@ -15,7 +15,7 @@ enum SelfIntroduceService {
         crewID: Int,
         nickName: String,
         description: String,
-        firstSubway: String,
+        firstSubway: String? = nil,
         secondSubway: String? = nil
     )
 }
@@ -69,20 +69,30 @@ extension SelfIntroduceService: TargetType {
             return .requestParameters(parameters: param, encoding: URLEncoding.queryString)
             
         case .registerUserSubwayStations(_, let nickName, let description, let firstSubway, let secondSubway):
-            guard let secondSubway = secondSubway else {
-                let param: [String : Any] = [
-                    "nickname" : nickName,
-                    "description" : description,
-                    "firstSubway" : firstSubway
-                ]
+            var param: [String:Any] = [
+                "nickname" : nickName,
+                "description" : description
+            ]
+            
+            guard let firstSubway = firstSubway else {
                 return .requestParameters(parameters: param, encoding: JSONEncoding.default)
             }
-            let param: [String : Any] = [
+            param = [
+                "nickname" : nickName,
+                "description" : description,
+                "firstSubway" : firstSubway
+            ]
+
+            guard let secondSubway = secondSubway else {
+                return .requestParameters(parameters: param, encoding: JSONEncoding.default)
+            }
+            param = [
                 "nickname" : nickName,
                 "description" : description,
                 "firstSubway" : firstSubway,
                 "secondSubway" : secondSubway
             ]
+            
             return .requestParameters(parameters: param, encoding: JSONEncoding.default)
         }
     }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceService.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/Network/SelfIntroduceService.swift
@@ -10,13 +10,13 @@ import Foundation
 
 enum SelfIntroduceService {
     case searchStationRequeset
-    case existingNicknameRequset(crewID: Int, Nickname: String)
+    case existingNicknameRequset(crewID: Int, nickName: String)
     case registerUserSubwayStations(
         crewID: Int,
         nickName: String,
         description: String,
-        firstSubway: String? = nil,
-        secondSubway: String? = nil
+        firstSubway: String?,
+        secondSubway: String?
     )
 }
 

--- a/PlayTogether/PlayTogether/Sources/Onboarding/View/PreferredStationCollectionViewCell.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/View/PreferredStationCollectionViewCell.swift
@@ -9,15 +9,13 @@ import UIKit
 import RxSwift
 
 final class PreferredStationCollectionViewCell: UICollectionViewCell {
-    private lazy var disposeBag = DisposeBag()
-    
-    private lazy var titleLabel = UILabel().then {
+    private let titleLabel = UILabel().then {
         $0.text = ""
         $0.font = .pretendardMedium(size: 14)
         $0.textColor = .ptGreen
     }
     
-    lazy var cancelButton = UIButton().then {
+    private let cancelButton = UIButton().then {
         $0.setImage(.ptImage(.exitIcon), for: .normal)
         $0.tintColor = .ptGray01
     }
@@ -26,6 +24,15 @@ final class PreferredStationCollectionViewCell: UICollectionViewCell {
         super.init(frame: frame)
         
         setupView()
+        setupLayout()
+    }
+
+    var cancelButtonTapObservable: Observable<String> {
+        cancelButton.rx.tap
+            .asObservable()
+            .map { [weak self] in
+                self?.titleLabel.text ?? ""
+            }
     }
     
     required init?(coder: NSCoder) {
@@ -40,8 +47,6 @@ private extension PreferredStationCollectionViewCell {
         
         addSubview(titleLabel)
         addSubview(cancelButton)
-        
-        setupLayout()
     }
     
     func setupLayout() {

--- a/PlayTogether/PlayTogether/Sources/Onboarding/View/PreferredStationCollectionViewCell.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/View/PreferredStationCollectionViewCell.swift
@@ -64,8 +64,7 @@ private extension PreferredStationCollectionViewCell {
 }
 
 extension PreferredStationCollectionViewCell {
-    func setupData(_ title: String, _ tag: Int) {
+    func setupData(title: String) {
         titleLabel.text = title
-        cancelButton.tag = tag
     }
 }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/AddSubwayStationViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/AddSubwayStationViewController.swift
@@ -9,8 +9,8 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-protocol AddSubwayStationDelegate {
-    func registerSubwayStation(_ stations: [String])
+protocol AddSubwayStationDelegate: AnyObject {
+    func registerSubwayStation(_ stations: [String?])
 }
 
 class AddSubwayStationViewController: BaseViewController {
@@ -95,7 +95,7 @@ class AddSubwayStationViewController: BaseViewController {
     private lazy var selectedSubwayStations = [String]()
     private var selectedSubwayStationRelay = BehaviorRelay<[String]>(value: [])
     private var collectionViewHeight: CGFloat = 0
-    var delegate: AddSubwayStationDelegate?
+    weak var delegate: AddSubwayStationDelegate?
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -296,11 +296,11 @@ extension AddSubwayStationViewController: UICollectionViewDataSource, UICollecti
             selectedSubwayStationRelay.value[row],
             row
         )
-        cell.cancelButton.addTarget(
-            self,
-            action: #selector(cellCancelAction),
-            for: .touchUpInside
-        )
+//        cell.cancelButton.addTarget(
+//            self,
+//            action: #selector(cellCancelAction),
+//            for: .touchUpInside
+//        )
         
         return cell
     }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/AddSubwayStationViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/AddSubwayStationViewController.swift
@@ -295,8 +295,7 @@ extension AddSubwayStationViewController: UICollectionViewDataSource, UICollecti
         let row = indexPath.row
         
         cell.setupData(
-            selectedSubwayStationRelay.value[row],
-            row
+            title: selectedSubwayStationRelay.value[row]
         )
         
         cell.cancelButtonTapObservable

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/AddSubwayStationViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/AddSubwayStationViewController.swift
@@ -13,7 +13,7 @@ protocol AddSubwayStationDelegate: AnyObject {
     func registerSubwayStation(_ stations: [String?])
 }
 
-class AddSubwayStationViewController: BaseViewController {
+final class AddSubwayStationViewController: BaseViewController {
     private let disposeBag = DisposeBag()
     private let viewModel = AddSubwayStationViewModel()
     

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/CreateMeetViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/CreateMeetViewController.swift
@@ -298,6 +298,7 @@ class CreateMeetViewController: BaseViewController {
             .asDriver()
             .drive(onNext: { [weak self] in
                 self?.isEnableMeetingTitle.accept(true)
+                self?.view.endEditing(true)
             })
             .disposed(by: disposeBag)
         

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/OpendThunViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/OpendThunViewController.swift
@@ -82,6 +82,13 @@ class OpendThunViewController: BaseViewController {
     }
     
     override func setupBinding() {
+        leftButtonItem.rx.tap
+            .asDriver()
+            .drive(onNext: { [weak self] in
+                self?.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: disposeBag)
+        
         startButton.rx.tap
             .asDriver()
             .drive(onNext: { _ in

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
@@ -144,28 +144,12 @@ class SelfIntroduceViewController: BaseViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        configureNavbar()
-    }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-    }
-    
-    private func configureNavbar() {
         navigationItem.leftBarButtonItem = leftButtonItem
         navigationItem.leftBarButtonItem?.tintColor = .white
     }
     
-    private func changeNextButtonUI(_ button: UIButton , _ status: Bool) {
-        guard status == true else {
-            button.isEnabled = false
-            button.backgroundColor = .ptGray03
-            button.layer.borderColor = UIColor.ptGray02.cgColor
-            return
-        }
-        button.isEnabled = true
-        button.backgroundColor = .ptGreen
-        button.layer.borderColor = UIColor.ptBlack01.cgColor
+    override func viewDidLoad() {
+        super.viewDidLoad()
     }
     
     override func setupViews() {
@@ -368,9 +352,8 @@ class SelfIntroduceViewController: BaseViewController {
         
         Driver.combineLatest(
             isEnableNickname.asDriver(),
-            isFillBriefIntroduceText.asDriver(),
-            registerUserStationsRelay.asDriver()
-        ) { $0 && $1 && !$2.contains("선택 사항 없음") && $2.count > 0 }
+            isFillBriefIntroduceText.asDriver()
+        ) { $0 && $1 }
             .drive(onNext: { [weak self] in
                 guard let self = self else { return }
                 self.changeNextButtonUI(self.nextButton, $0)
@@ -409,6 +392,21 @@ class SelfIntroduceViewController: BaseViewController {
             })
             .disposed(by: disposeBag)
     }
+}
+
+// MARK: - Custom helper
+private extension SelfIntroduceViewController {
+    func changeNextButtonUI(_ button: UIButton , _ status: Bool) {
+        guard status == true else {
+            button.isEnabled = false
+            button.backgroundColor = .ptGray03
+            button.layer.borderColor = UIColor.ptGray02.cgColor
+            return
+        }
+        button.isEnabled = true
+        button.backgroundColor = .ptGreen
+        button.layer.borderColor = UIColor.ptBlack01.cgColor
+    }
     
     func createMeetRequest(_ response: Single<Response>) {
         response.subscribe(onSuccess: { [weak self] response in
@@ -429,6 +427,7 @@ class SelfIntroduceViewController: BaseViewController {
 }
 
 
+// MARK: - Etc delegate
 extension SelfIntroduceViewController: AddSubwayStationDelegate {
     func registerSubwayStation(_ stations: [String]) {
         registerUserStationsArray = (stations.isEmpty ? ["선택 사항 없음"] : stations)

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
@@ -8,7 +8,6 @@
 import UIKit
 import RxSwift
 import RxCocoa
-import Moya
 
 final class SelfIntroduceViewController: BaseViewController {
     private let disposeBag = DisposeBag()
@@ -405,13 +404,12 @@ private extension SelfIntroduceViewController {
         OnboardingDataModel.shared.preferredSubway = registerUserStationsRelay.value
     }
     
-    func createMeetRequest(_ observable: Observable<Response>) {
+    func createMeetRequest(_ observable: Observable<SelfIntroduceResponse>) {
         observable
             .observe(on: MainScheduler.instance)
             .subscribe(with: self, onNext: { owner, response in
-                let responseData = try? response.map(SelfIntroduceResponse.self)
-                guard responseData?.status == 200 else {
-                    owner.showToast(responseData?.message ?? "")
+                guard response.status == 200 else {
+                    owner.showToast(response.message)
                     return
                 }
                 

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
@@ -20,8 +20,8 @@ final class SelfIntroduceViewController: BaseViewController {
     }
     
     private let headerLabel = UILabel().then {
-        let title = OnboardingDataModel.shared
-        $0.text = "\(title.meetingTitle ?? "테스트 동아리")에서\n나는 어떤 사람인가요?"
+        let title = OnboardingDataModel.shared.meetingTitle
+        $0.text = "\(title ?? "테스트 동아리")에서\n나는 어떤 사람인가요?"
         $0.font = .pretendardMedium(size: 22)
         $0.textColor = .ptBlack01
         $0.numberOfLines = 0
@@ -33,15 +33,16 @@ final class SelfIntroduceViewController: BaseViewController {
         $0.font = .pretendardBold(size: 14)
     }
     
-    private lazy var existingNicknameButton = UIButton().then {
-        $0.backgroundColor = .ptBlack01
+    private let nickNameCheckButton = UIButton().then {
+        $0.backgroundColor = .ptGray03
         $0.setTitle("중복확인", for: .normal)
         $0.setTitleColor(.white, for: .normal)
         $0.titleLabel?.font = .pretendardMedium(size: 12)
+        $0.isEnabled = false
         $0.layer.cornerRadius = 5
     }
     
-    private let inputNicknameTextField = UITextField().then {
+    private let nickNameTextField = UITextField().then {
         $0.font = .pretendardRegular(size: 14)
         $0.textColor = .ptBlack01
         $0.setupPlaceholderText(title: "닉네임 입력", color: .ptGray01)
@@ -52,8 +53,8 @@ final class SelfIntroduceViewController: BaseViewController {
         $0.layer.borderColor = UIColor.ptGray03.cgColor
     }
     
-    private let noticeNicknameLabel = UILabel().then {
-        $0.text = "10자 이내(공백 제외) 한글,영문,숫자,특수문자"
+    private let noticeNickNameLabel = UILabel().then {
+        $0.text = "2 ~ 10자(공백 불가) 한글, 영문, 숫자, 언더바(_) 사용 가능"
         $0.textColor = .ptGray02
         $0.font = .pretendardMedium(size: 12)
     }
@@ -75,7 +76,7 @@ final class SelfIntroduceViewController: BaseViewController {
         $0.font = .pretendardMedium(size: 10)
     }
     
-    private let inputBriefIntroduceTextView = UITextView().then {
+    private let briefIntroduceTextView = UITextView().then {
         $0.text = "간단 소개 입력"
         $0.font = .pretendardRegular(size: 14)
         $0.textColor = .ptGray01
@@ -99,7 +100,7 @@ final class SelfIntroduceViewController: BaseViewController {
         $0.font = .pretendardMedium(size: 10)
     }
     
-    private lazy var addPreferredSubwayStationButton = UIButton().then {
+    private let addPreferredSubwayStationButton = UIButton().then {
         $0.setTitle("추가하기", for: .normal)
         $0.setTitleColor(.ptGray01, for: .normal)
         $0.titleLabel?.font = .pretendardMedium(size: 12)
@@ -117,39 +118,38 @@ final class SelfIntroduceViewController: BaseViewController {
     ).then {
         $0.backgroundColor = .white
         $0.contentInset = .zero
-        $0.register(SubwayStationCollectionViewCell.self, forCellWithReuseIdentifier: "SubwayStationCollectionViewCell")
-        $0.register(PreferredStationCollectionViewCell.self, forCellWithReuseIdentifier: "PreferredStationCollectionViewCell")
+        $0.register(
+            SubwayStationCollectionViewCell.self,
+            forCellWithReuseIdentifier: "SubwayStationCollectionViewCell"
+        )
+        $0.register(
+            PreferredStationCollectionViewCell.self,
+            forCellWithReuseIdentifier: "PreferredStationCollectionViewCell"
+        )
         
         $0.delegate = self
         $0.dataSource = self
     }
     
-    private lazy var nextButton = UIButton().then {
+    private let nextButton = UIButton().then {
         $0.setupBottomButtonUI(title: "다음", size: 15)
         $0.isButtonEnableUI(check: false)
     }
     
-    private let leftButtonItem = UIBarButtonItem(image: UIImage.ptImage(.backIcon), style: .plain, target: SelfIntroduceViewController.self, action: nil)
-    
-    private var isEnableNickname = BehaviorRelay<Bool>(value: false)
-    private var isFillBriefIntroduceText = BehaviorRelay<Bool>(value: false)
-    private var registerUserStationsRelay = BehaviorRelay<[String]>(value: ["선택 사항 없음"])
-    private var ableNickname: String = ""
-    private var inputNickNameTextFieldText: String {
-        return inputNicknameTextField.text ?? ""
-    }
-    private var inputBriefIntroduceTextViewText: String {
-        return inputBriefIntroduceTextView.text ?? ""
-    }
+    private let leftButtonItem = UIBarButtonItem(
+        image: UIImage.ptImage(.backIcon),
+        style: .plain,
+        target: SelfIntroduceViewController.self,
+        action: nil
+    )
+
+    private let subwayRelay = BehaviorRelay<[String?]>(value: [nil, nil])
+    private let isPassedNickNameCheck = PublishSubject<Bool>()
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationItem.leftBarButtonItem = leftButtonItem
         navigationItem.leftBarButtonItem?.tintColor = .white
-    }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
     }
     
     override func setupViews() {
@@ -158,13 +158,13 @@ final class SelfIntroduceViewController: BaseViewController {
         view.addSubview(progressbar)
         view.addSubview(headerLabel)
         view.addSubview(nickNameLabel)
-        view.addSubview(inputNicknameTextField)
-        view.addSubview(existingNicknameButton)
-        view.addSubview(noticeNicknameLabel)
+        view.addSubview(nickNameTextField)
+        view.addSubview(nickNameCheckButton)
+        view.addSubview(noticeNickNameLabel)
         view.addSubview(noticeExistingNicknameLabel)
         view.addSubview(briefIntroductionLabel)
         view.addSubview(briefIntroductionSubLabel)
-        view.addSubview(inputBriefIntroduceTextView)
+        view.addSubview(briefIntroduceTextView)
         view.addSubview(preferredSubwayStationLabel)
         view.addSubview(preferredSubwayStationSubLabel)
         view.addSubview(addPreferredSubwayStationButton)
@@ -189,25 +189,25 @@ final class SelfIntroduceViewController: BaseViewController {
             $0.top.equalTo(headerLabel.snp.bottom).offset(36)
         }
         
-        noticeNicknameLabel.snp.makeConstraints {
+        noticeNickNameLabel.snp.makeConstraints {
             $0.centerY.equalTo(nickNameLabel.snp.centerY)
             $0.leading.equalTo(nickNameLabel.snp.trailing).offset(6)
         }
         
-        inputNicknameTextField.snp.makeConstraints {
+        nickNameTextField.snp.makeConstraints {
             $0.top.equalTo(nickNameLabel.snp.bottom).offset(14)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(57 * (UIScreen.main.bounds.height / 812))
         }
         
         noticeExistingNicknameLabel.snp.makeConstraints {
-            $0.top.equalTo(inputNicknameTextField.snp.bottom).offset(10)
+            $0.top.equalTo(nickNameTextField.snp.bottom).offset(10)
             $0.leading.equalToSuperview().inset(24)
         }
         
-        existingNicknameButton.snp.makeConstraints {
-            $0.centerY.equalTo(inputNicknameTextField)
-            $0.trailing.equalTo(inputNicknameTextField.snp.trailing).inset(16)
+        nickNameCheckButton.snp.makeConstraints {
+            $0.centerY.equalTo(nickNameTextField)
+            $0.trailing.equalTo(nickNameTextField.snp.trailing).inset(16)
             $0.width.equalTo(67 * (UIScreen.main.bounds.width / 375))
         }
         
@@ -221,14 +221,14 @@ final class SelfIntroduceViewController: BaseViewController {
             $0.leading.equalTo(briefIntroductionLabel.snp.trailing).offset(6)
         }
         
-        inputBriefIntroduceTextView.snp.makeConstraints {
+        briefIntroduceTextView.snp.makeConstraints {
             $0.top.equalTo(briefIntroductionLabel.snp.bottom).offset(14)
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(100 * (UIScreen.main.bounds.height / 812))
         }
         
         preferredSubwayStationLabel.snp.makeConstraints {
-            $0.top.equalTo(inputBriefIntroduceTextView.snp.bottom).offset(36)
+            $0.top.equalTo(briefIntroduceTextView.snp.bottom).offset(36)
             $0.leading.equalToSuperview().inset(20)
         }
         
@@ -256,194 +256,186 @@ final class SelfIntroduceViewController: BaseViewController {
     }
     
     override func setupBinding() {
-        leftButtonItem.rx.tap
-            .asDriver()
-            .drive(with: self, onNext: { owner, _ in
-                owner.navigationController?.popViewController(animated: true)
-            })
-            .disposed(by: disposeBag)
-        
-        existingNicknameButton.rx.tap
-            .asDriver()
-            .flatMapLatest { [weak self] _ -> Driver<Bool> in
-                guard let self = self else { return .just(false) }
-                
-                let input = SelfIntroduceViewModel.CheckNicknameInput(
-                    nickname: self.inputNickNameTextFieldText
-                )
-                return self.viewModel.checkNickname(input)
-                    .asDriver(onErrorJustReturn: false)
-            }
-            .drive(with: self, onNext: { owner, exists in
-                owner.isEnableNickname.accept(exists)
+        let input = SelfIntroduceViewModel.Input(
+            tapNickNameButton: nickNameCheckButton.rx.tap,
+            tapNextButton: nextButton.rx.tap,
+            nickNameInput: nickNameTextField.rx.text.orEmpty.asObservable(),
+            descriptionInput: briefIntroduceTextView.rx.text.orEmpty.asObservable(),
+            subwayInput: subwayRelay.asObservable()
+        )
+
+        let output = viewModel.transform(input)
+
+        output.checkNickNameOutput
+            .asSignal(onErrorJustReturn: false)
+            .emit(with: self, onNext: { owner, isEnable in
                 owner.noticeExistingNicknameLabel.isHidden = false
-                owner.noticeExistingNicknameLabel.text = exists ? "사용 가능한 닉네임입니다" : "이미 사용중인 닉네임입니다"
-                owner.noticeExistingNicknameLabel.textColor = exists ? .ptCorrect : .ptIncorrect
-                
-                guard exists == true else { return }
-                owner.ableNickname = owner.inputNickNameTextFieldText
+                owner.noticeExistingNicknameLabel.text = isEnable ? "사용 가능한 닉네임입니다" : "이미 사용중인 닉네임입니다"
+                owner.noticeExistingNicknameLabel.textColor = isEnable ? .ptCorrect : .ptIncorrect
+                owner.isPassedNickNameCheck.onNext(isEnable)
             })
-            .disposed(by: disposeBag)
-        
-        inputNicknameTextField.rx.controlEvent(.touchDown)
-            .asDriver()
-            .map { UIColor.ptBlack02.cgColor }
-            .drive(inputNicknameTextField.layer.rx.borderColor)
             .disposed(by: disposeBag)
 
-        inputNicknameTextField.rx.controlEvent([.editingDidEnd, .editingDidEndOnExit])
-            .asDriver()
-            .drive(with: self, onNext: { owner, _ in
-                let textCount: Int = owner.inputNickNameTextFieldText.count
-                owner.inputNicknameTextField.layer.borderColor = textCount > 0 ?
-                    UIColor.ptGray02.cgColor : UIColor.ptGray01.cgColor
-            })
-            .disposed(by: disposeBag)
-        
-        inputNicknameTextField.rx.text.orEmpty
-            .asDriver()
-            .drive(with: self, onNext: { owner, text in
-                guard text != owner.ableNickname else { return }
-                
-                owner.noticeExistingNicknameLabel.isHidden = true
-                owner.isEnableNickname.accept(false)
-                
-                guard text.count > 10 else { return }
-                owner.inputNicknameTextField.text = String(owner.inputNicknameTextField.text?.dropLast() ?? "")
-            })
-            .disposed(by: disposeBag)
-        
-        inputBriefIntroduceTextView.rx.text.orEmpty
-            .asDriver()
-            .map { [weak self] text in
-                return text.count > 0 && self?.inputBriefIntroduceTextView.textColor == .ptBlack01
+        output.registUserProfileOutput
+            .withUnretained(self)
+            .filter { owner, response in
+                let isSuccess = response.status == 200
+                if !isSuccess { owner.showToast(response.message) }
+
+                return isSuccess
             }
-            .drive(isFillBriefIntroduceText)
-            .disposed(by: disposeBag)
-        
-        inputBriefIntroduceTextView.rx.didBeginEditing
-            .asDriver()
-            .drive(with: self, onNext: { owner, _ in
-                guard owner.inputBriefIntroduceTextView.textColor == .ptGray01 else { return }
-                owner.inputBriefIntroduceTextView.layer.borderColor = UIColor.ptBlack02.cgColor
-                owner.inputBriefIntroduceTextView.textColor = .ptBlack01
-                owner.inputBriefIntroduceTextView.text = nil
-            })
-            .disposed(by: disposeBag)
-        
-        inputBriefIntroduceTextView.rx.didEndEditing
-            .asDriver()
-            .drive(with: self, onNext: { owner, _ in
-                let textIsEmpty: Bool = owner.inputBriefIntroduceTextViewText.isEmpty
-                if textIsEmpty {
-                    owner.inputBriefIntroduceTextView.text = "간단 소개 입력"
-                    owner.isFillBriefIntroduceText.accept(textIsEmpty)
-                }
-                owner.inputBriefIntroduceTextView.textColor = textIsEmpty ? .ptGray01 : .ptBlack01
-                owner.inputBriefIntroduceTextView.layer.borderColor = textIsEmpty ?
-                    UIColor.ptGray03.cgColor : UIColor.ptGray01.cgColor
-            })
-            .disposed(by: disposeBag)
-        
-        registerUserStationsRelay
-            .asDriver()
-            .drive(with: self, onNext: { owner, _ in
-                owner.subwayStationCollectionView.reloadData()
-            })
-            .disposed(by: disposeBag)
-        
-        var buttonUIBinder: Binder<Bool> {
-            .init(self, binding: { owner, status in
-                owner.changeNextButtonUI(status)
-            })
-        }
-        Driver.combineLatest(
-            isEnableNickname.asDriver(),
-            isFillBriefIntroduceText.asDriver()
-        ) { $0 && $1 }
-            .drive(buttonUIBinder)
-            .disposed(by: disposeBag)
-        
-        addPreferredSubwayStationButton.rx.tap
-            .asDriver()
-            .drive(with: self, onNext: { owner, _ in
-                let controller = AddSubwayStationViewController()
-                controller.delegate = owner
-                owner.navigationController?.pushViewController(controller, animated: true)
-            })
-            .disposed(by: disposeBag)
-        
-        let nextButtonOnNext: () -> Void = { [weak self] in
-            guard let self = self else { return }
-            
-            self.createMeetRequest(
-                self.viewModel.registerUserProfile(
-                    self.inputNickNameTextFieldText,
-                    self.inputBriefIntroduceTextViewText
-                )
-            )
-        }
-        nextButton.rx.tap
-            .asDriver()
-            .drive(onNext: nextButtonOnNext)
-            .disposed(by: disposeBag)
-    }
-}
+            .asSignal(onErrorSignalWith: .empty())
+            .emit(with: self, onNext: { owner, _ in
+                OnboardingDataModel.shared.nickName = owner.nickNameTextField.text ?? ""
+                OnboardingDataModel.shared.introduceSelfMessage = owner.briefIntroduceTextView.text
+                OnboardingDataModel.shared.preferredSubway = owner.subwayRelay.value
 
-// MARK: - Custom helper
-private extension SelfIntroduceViewController {
-    func changeNextButtonUI(_ isEnable: Bool) {
-        nextButton.isEnabled = isEnable
-        nextButton.backgroundColor = isEnable ? .ptGreen : .ptGray03
-        nextButton.layer.borderColor = isEnable ? UIColor.ptBlack01.cgColor : UIColor.ptGray02.cgColor
-    }
-    
-    func onboadingDataModelBinding() {
-        OnboardingDataModel.shared.nickName = inputNickNameTextFieldText
-        OnboardingDataModel.shared.introduceSelfMessage = inputBriefIntroduceTextViewText
-        OnboardingDataModel.shared.preferredSubway = registerUserStationsRelay.value
-    }
-    
-    func createMeetRequest(_ observable: Observable<SelfIntroduceResponse>) {
-        observable
-            .observe(on: MainScheduler.instance)
-            .subscribe(with: self, onNext: { owner, response in
-                guard response.status == 200 else {
-                    owner.showToast(response.message)
-                    return
-                }
-                
-                owner.onboadingDataModelBinding()
                 let isCreate: Bool = OnboardingDataModel.shared.isCreated ?? false
                 let controller = isCreate ? OpendThunViewController() : ParticipationCompletedViewController()
                 owner.navigationController?.pushViewController(controller, animated:  true)
             })
             .disposed(by: disposeBag)
+
+        leftButtonItem.rx.tap
+            .asSignal()
+            .emit(with: self, onNext: { owner, _ in
+                owner.navigationController?.popViewController(animated: true)
+            })
+            .disposed(by: disposeBag)
+        
+        nickNameTextField.rx.controlEvent(.touchDown)
+            .asSignal()
+            .map { UIColor.ptBlack02.cgColor }
+            .emit(to: nickNameTextField.layer.rx.borderColor)
+            .disposed(by: disposeBag)
+
+        nickNameTextField.rx.controlEvent(.editingDidEnd)
+            .withUnretained(self)
+            .asSignal(onErrorSignalWith: .empty())
+            .map { owner, _ in
+                let count = owner.nickNameTextField.text?.count ?? 0
+                return count > 0 ? UIColor.ptBlack02.cgColor : UIColor.ptGray03.cgColor
+            }
+            .emit(to: nickNameTextField.layer.rx.borderColor)
+            .disposed(by: disposeBag)
+
+        nickNameTextField.rx.text.orEmpty
+            .map(changeValidNickName)
+            .map(setupNickNameCheckButton)
+            .bind(to: nickNameTextField.rx.text)
+            .disposed(by: disposeBag)
+        
+        briefIntroduceTextView.rx.didBeginEditing
+            .withUnretained(self)
+            .filter { owner, _ in owner.briefIntroduceTextView.textColor == .ptGray01 }
+            .asSignal(onErrorSignalWith: .empty())
+            .emit(with: self, onNext: { owner, _ in
+                owner.briefIntroduceTextView.layer.borderColor = UIColor.ptBlack02.cgColor
+                owner.briefIntroduceTextView.textColor = .ptBlack01
+                owner.briefIntroduceTextView.text = nil
+            })
+            .disposed(by: disposeBag)
+        
+        briefIntroduceTextView.rx.didEndEditing
+            .withUnretained(self)
+            .map { owner, _ in owner.briefIntroduceTextView.text.isEmpty }
+            .asSignal(onErrorJustReturn: true)
+            .emit(with: self, onNext: { owner, textIsEmpty in
+                if textIsEmpty { owner.briefIntroduceTextView.text = "간단 소개 입력" }
+                owner.briefIntroduceTextView.textColor = textIsEmpty ? .ptGray01 : .ptBlack01
+                owner.briefIntroduceTextView.layer.borderColor = textIsEmpty ?
+                    UIColor.ptGray03.cgColor : UIColor.ptGray01.cgColor
+            })
+            .disposed(by: disposeBag)
+
+        Observable.combineLatest(
+            isPassedNickNameCheck.asObservable(),
+            briefIntroduceTextView.rx.text.orEmpty.asObservable()
+        )
+        .map { $0 && !$1.isEmpty && $1 != "간단 소개 입력" }
+        .asSignal(onErrorJustReturn: false)
+        .emit(with: self, onNext: { owner, isEnable in
+            owner.nextButton.isEnabled = isEnable
+            owner.nextButton.backgroundColor = isEnable ? .ptGreen : .ptGray03
+            owner.nextButton.layer.borderColor = isEnable ? UIColor.ptBlack01.cgColor : UIColor.ptGray02.cgColor
+        })
+        .disposed(by: disposeBag)
+        
+        addPreferredSubwayStationButton.rx.tap
+            .asSignal()
+            .emit(with: self, onNext: { owner, _ in
+                let viewController = AddSubwayStationViewController()
+                viewController.delegate = owner
+                owner.navigationController?.pushViewController(viewController, animated: true)
+            })
+            .disposed(by: disposeBag)
+
+        subwayRelay
+            .asSignal(onErrorJustReturn: [nil, nil])
+            .emit(with: self, onNext: { owner, _ in
+                owner.subwayStationCollectionView.reloadData()
+            })
+            .disposed(by: disposeBag)
     }
 }
 
+// MARK: - Private
+private extension SelfIntroduceViewController {
+    func changeValidNickName(_ text: String) -> String {
+        noticeExistingNicknameLabel.isHidden = true
+        isPassedNickNameCheck.onNext(false)
+        guard let lastText = text.last else { return text }
+
+        let regularExpression = String(lastText).range(
+            of: "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\_]$",
+            options: .regularExpression
+        )
+
+        if lastText == " " || text.count > 10 || regularExpression == nil {
+            noticeNickNameLabel.textColor = .ptIncorrect
+            return String(text.dropLast())
+        }
+
+        noticeNickNameLabel.textColor = .ptGray02
+        return text
+      }
+
+    func setupNickNameCheckButton(_ text: String) -> String {
+        let isEnable = text.count >= 2
+        nickNameCheckButton.backgroundColor = isEnable ? .ptBlack01 : .ptGray03
+        nickNameCheckButton.isEnabled = isEnable
+
+        return text
+    }
+}
 
 // MARK: - Etc delegate
 extension SelfIntroduceViewController: AddSubwayStationDelegate {
-    func registerSubwayStation(_ stations: [String]) {
-        registerUserStationsRelay.accept(stations.isEmpty ? ["선택 사항 없음"] : stations)
+    func registerSubwayStation(_ stations: [String?]) {
+        var stations = stations
+        if stations.count == 1 { stations.append(nil) }
+
+        subwayRelay.accept(stations)
     }
 }
 
-extension SelfIntroduceViewController: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
-    @objc
-    func cellCancelAction(_ sender: UIButton) {
-        var removeForStations: [String] = registerUserStationsRelay.value
-        removeForStations.remove(at: sender.tag)
-        registerUserStationsRelay.accept(removeForStations)
+extension SelfIntroduceViewController
+: UICollectionViewDelegate, UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    ) -> Int {
+        let dataSource = subwayRelay.value.compactMap {($0)}
+        return dataSource.isEmpty ? 1 : dataSource.count
     }
     
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return registerUserStationsRelay.value.count
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard !registerUserStationsRelay.value.contains("선택 사항 없음") else {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        let dataSource = subwayRelay.value.compactMap {($0)}
+
+        guard !dataSource.isEmpty else {
             let emptyCell = self.subwayStationCollectionView.dequeueReusableCell(
                 withReuseIdentifier: "SubwayStationCollectionViewCell",
                 for: indexPath
@@ -457,22 +449,38 @@ extension SelfIntroduceViewController: UICollectionViewDelegate, UICollectionVie
             withReuseIdentifier: "PreferredStationCollectionViewCell",
             for: indexPath
         ) as! PreferredStationCollectionViewCell
-        
-        cell.setupData(
-            registerUserStationsRelay.value[row],
-            row
-        )
-        cell.cancelButton.addTarget(
-            self,
-            action: #selector(cellCancelAction),
-            for: .touchUpInside
-        )
+
+        cell.setupData(dataSource[row], row)
+
+        cell.cancelButtonTapObservable
+            .bind(with: self, onNext: { owner, textString in
+                var stations = owner.subwayRelay.value
+                guard let removeIndex = stations.firstIndex(of: textString) else { return }
+
+                stations.remove(at: removeIndex)
+                stations.append(nil)
+                owner.subwayRelay.accept(stations)
+            })
+            .disposed(by: disposeBag)
         
         return cell
     }
     
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let fontWidth = (registerUserStationsRelay.value[indexPath.row] as NSString).size(
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        sizeForItemAt indexPath: IndexPath
+    ) -> CGSize {
+        var textString = subwayRelay.value[indexPath.row]
+
+        if textString == nil {
+            guard indexPath.row == 0 else { return .zero }
+            textString = "선택 사항 없음"
+        }
+
+        guard let textString = textString else { return .zero }
+
+        let fontWidth = (textString as NSString).size(
             withAttributes: [NSAttributedString.Key.font: UIFont.pretendardMedium(size: 14)]
         ).width
         let cellWidth = fontWidth + 34 + 16 * (UIScreen.main.bounds.width / 375)

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
@@ -281,6 +281,8 @@ class SelfIntroduceViewController: BaseViewController {
         existingNicknameButton.rx.tap
             .asDriver()
             .drive(onNext: { [weak self] in
+                self?.view.endEditing(true)
+                
                 guard let nickname = self?.inputNicknameTextField.text,
                       let crewId = OnboardingDataModel.shared.crewId
                 else { return }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
@@ -369,7 +369,7 @@ class SelfIntroduceViewController: BaseViewController {
             isEnableNickname.asDriver(),
             isFillBriefIntroduceText.asDriver(),
             registerUserStationsRelay.asDriver()
-        ) { $0 && $1 && !$2.isEmpty }
+        ) { $0 && $1 && !$2.contains("선택 사항 없음") && $2.count > 0 }
             .drive(onNext: { [weak self] in
                 guard let self = self else { return }
                 self.changeNextButtonUI(self.nextButton, $0)

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
@@ -450,7 +450,7 @@ extension SelfIntroduceViewController
             for: indexPath
         ) as! PreferredStationCollectionViewCell
 
-        cell.setupData(dataSource[row], row)
+        cell.setupData(title: dataSource[row])
 
         cell.cancelButtonTapObservable
             .bind(with: self, onNext: { owner, textString in

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewController/SelfIntroduceViewController.swift
@@ -281,8 +281,10 @@ class SelfIntroduceViewController: BaseViewController {
         existingNicknameButton.rx.tap
             .asDriver()
             .drive(onNext: { [weak self] in
-                guard let nickname = self?.inputNicknameTextField.text else { return }
-                self?.viewModel.checkNickname(102, nickname) {  // TODO: 추후 동아리 번호 받아올 예정
+                guard let nickname = self?.inputNicknameTextField.text,
+                      let crewId = OnboardingDataModel.shared.crewId
+                else { return }
+                self?.viewModel.checkNickname(crewId, nickname) {
                     self?.isEnableNickname.accept($0)
                     self?.noticeExistingNicknameLabel.isHidden = false
                     self?.noticeExistingNicknameLabel.text = $0 ? "사용 가능한 닉네임입니다" : "이미 사용중인 닉네임입니다"

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/CreateMeetViewModel.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/CreateMeetViewModel.swift
@@ -37,7 +37,7 @@ final class CreateMeetViewModel {
     
     func regularExpressionCheck(input: RegularExpressionInput) -> RegularExpressionOutput {
         let output = input.meetingTitleText.map {
-            let pattern = "^[0-9a-zㅏ-ㅣA-Zㄱ-ㅎ가-핳\\s]*$"
+            let pattern = "^[0-9a-zㅏ-ㅣA-Zㄱ-ㅎ가-힣\\s]*$"
             guard let _ = $0.range(of: pattern, options: .regularExpression) else { return false }
             return true
         }.asDriver(onErrorJustReturn: false)

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
@@ -35,7 +35,7 @@ final class SelfIntroduceViewModel {
         _ description: String,
         _ firstSubway: String? = nil,
         _ secondSubway: String? = nil
-    ) -> Observable<Response> {
+    ) -> Observable<SelfIntroduceResponse> {
         return provider.rx.request(
             .registerUserSubwayStations(
                 crewID: OnboardingDataModel.shared.crewId ?? -1,
@@ -45,5 +45,6 @@ final class SelfIntroduceViewModel {
                 secondSubway: secondSubway
             ))
         .asObservable()
+        .map(SelfIntroduceResponse.self)
     }
 }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
@@ -15,39 +15,35 @@ final class SelfIntroduceViewModel {
     private lazy var disposeBag = DisposeBag()
     private let provider = MoyaProvider<SelfIntroduceService>()
     
-    struct checkNicknameInput {
-        var crewID: Int
-        var nickname: Observable<String>
+    struct CheckNicknameInput {
+        var nickname: String
     }
     
-    func checkNickname(_ crewId: Int, _ nickName: String, completion: @escaping (Bool) -> Void) {
-        provider.rx.request(.existingNicknameRequset(crewID: crewId, Nickname: nickName))
-            .subscribe { result in
-                switch result {
-                case .success(let response):
-                    completion(response.statusCode == 200)
-                case .failure(let error):
-                    print(error.localizedDescription)
-                }
-            }
-            .disposed(by: disposeBag)
+    func checkNickname(_ input: CheckNicknameInput) -> Driver<Bool> {
+        return provider.rx.request(.existingNicknameRequset(
+            crewID: OnboardingDataModel.shared.crewId ?? -1,
+            Nickname: input.nickname
+        ))
+        .map { response in
+            return response.statusCode == 200
+        }
+        .asDriver(onErrorJustReturn: false)
     }
     
     func registerUserProfile(
-        _ crewId: Int,
         _ nickName: String,
         _ description: String,
         _ firstSubway: String? = nil,
         _ secondSubway: String? = nil
-    ) -> Single<Response> {
-        let singleResponse: Single<Response> = provider.rx.request(
+    ) -> Observable<Response> {
+        return provider.rx.request(
             .registerUserSubwayStations(
-                crewID: crewId,
+                crewID: OnboardingDataModel.shared.crewId ?? -1,
                 nickName: nickName,
                 description: description,
                 firstSubway: firstSubway,
-                secondSubway: secondSubway)
-        )
-        return singleResponse
+                secondSubway: secondSubway
+            ))
+        .asObservable()
     }
 }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
@@ -37,7 +37,7 @@ final class SelfIntroduceViewModel {
         _ crewId: Int,
         _ nickName: String,
         _ description: String,
-        _ firstSubway: String,
+        _ firstSubway: String? = nil,
         _ secondSubway: String? = nil
     ) -> Single<Response> {
         let singleResponse: Single<Response> = provider.rx.request(

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
@@ -25,9 +25,7 @@ final class SelfIntroduceViewModel {
             .subscribe { result in
                 switch result {
                 case .success(let response):
-                    print(response)
-                    let statusCode = response.statusCode
-                    statusCode == 200 ? completion(true) : completion(false)
+                    completion(response.statusCode == 200)
                 case .failure(let error):
                     print(error.localizedDescription)
                 }

--- a/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
+++ b/PlayTogether/PlayTogether/Sources/Onboarding/ViewModel/SelfIntroduceViewModel.swift
@@ -38,26 +38,16 @@ final class SelfIntroduceViewModel {
         _ nickName: String,
         _ description: String,
         _ firstSubway: String,
-        _ secondSubway: String? = nil,
-        completion: @escaping (Bool) -> Void) {
-        provider.rx.request(
+        _ secondSubway: String? = nil
+    ) -> Single<Response> {
+        let singleResponse: Single<Response> = provider.rx.request(
             .registerUserSubwayStations(
                 crewID: crewId,
                 nickName: nickName,
                 description: description,
                 firstSubway: firstSubway,
                 secondSubway: secondSubway)
-        ).subscribe { result in
-            switch result {
-            case .success(let response):
-                guard let responseData = try? response.map(SelfIntroduceResponse.self)
-                else { return }
-                completion(responseData.status == 200)
-                
-            case .failure(let error):
-                print(error.localizedDescription)
-            }
-        }
-        .disposed(by: disposeBag)
+        )
+        return singleResponse
     }
 }

--- a/PlayTogether/PlayTogether/Utils/OnboardingDataModel.swift
+++ b/PlayTogether/PlayTogether/Utils/OnboardingDataModel.swift
@@ -17,7 +17,7 @@ class OnboardingDataModel {
     var preferredSubway: [String]?
     
     var crewId: Int?
-    var madeCrew: Bool?
+    var madeCrew: Bool = false
     
     private init() {}
 }

--- a/PlayTogether/PlayTogether/Utils/OnboardingDataModel.swift
+++ b/PlayTogether/PlayTogether/Utils/OnboardingDataModel.swift
@@ -14,7 +14,7 @@ class OnboardingDataModel {
     var inviteCode: String?
     var nickName: String?
     var introduceSelfMessage: String?
-    var preferredSubway: [String]?
+    var preferredSubway: [String?]?
     
     var crewId: Int?
     var madeCrew: Bool = false


### PR DESCRIPTION
### 📌 이슈 번호
- #128

### 📌 작업 내역
- [X] 동아리명 정규식 수정
- [X] 동아리명 입력 View → 자기소개 입력 View 넘어갈 때 로직 수정(동아리명 바인딩 X)
- [X] 자기소개 입력 View `다음`버튼 활성화 로직 수정
- [X] 자기소개 입력 후 넘어가는 로직(서버) 코드 리펙토링
- [X] 자기소개 지하철 데이터 [0개, 1개, 2개] 각각 버튼 활성화 및 API 성공하는지 체크
- [X] 개설완료 View 뒤로가기 기능 추가
- [X] 선호하는 지하철 데이터 추가 및 삭제 기능 개선

### Additionally
- 이슈들이 더 있고 기능 개발이 추가적으로 있으므로, (1)로 이슈를 만들었으며 추후 작업은 (2) 이슈와 함께 PR 할 예정입니다.
- 각각 작업 내용들은 위 작업 내역에서 참고할 수 있으니 참고 부탁드립니다.
